### PR TITLE
fix(network-ee): exclude ansible-core from pip to unblock build

### DIFF
--- a/network-ee/execution-environment.yml
+++ b/network-ee/execution-environment.yml
@@ -14,6 +14,9 @@ dependencies:
   galaxy: requirements.yml
   python: requirements.txt
   system: bindep.txt
+  exclude:
+    python:
+      - ansible-core
 
 options:
     package_manager_path: /usr/bin/microdnf


### PR DESCRIPTION
## Summary
- Added `exclude: python: [ansible-core]` to the EE definition. The AAP 2.6 base image already provides `ansible-core` via RPM, but collections (`ansible.controller>=4.6.2`, `ansible.platform>=2.5.3`) declare `ansible_core>=2.17.0` as a pip dependency. PyPI has no 2.17+ wheel compatible with RHEL 9's Python 3.9 platform interpreter, so the build fails. The exclude directive tells ansible-builder to skip it during pip resolution.

## Context
Follow-up to PR #71. The base image update alone didn't resolve the build failure because the `:latest` image still uses Python 3.9.

Made with [Cursor](https://cursor.com)