### PR TITLE
chore: bump ansible-builder to >=3.1.0 for exclude support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-ansible-builder==3.0.0
+ansible-builder>=3.1.0


### PR DESCRIPTION
## Summary
- Bumps `ansible-builder` from `==3.0.0` to `>=3.1.0` in the root `requirements.txt`
- Required so the `exclude: python: [ansible-core]` directive in the network-ee definition (PR #72) is recognized by the builder

## Context
PR #72 added the `exclude` block to skip pip-installing `ansible-core` (already in the base image via RPM). But ansible-builder 3.0.0 doesn't support that keyword and rejects it with a schema validation error.

Made with [Cursor](https://cursor.com)