### PR TITLE
fix(network-ee): trigger rebuild after ansible-builder bump

### DIFF
--- a/network-ee/execution-environment.yml
+++ b/network-ee/execution-environment.yml
@@ -1,4 +1,3 @@
-
 ---
 version: 3
 images:


### PR DESCRIPTION
No-op change (removed stray blank line) to trigger the build matrix for network-ee. The ansible-builder bump in PR #73 didn't touch the network-ee directory so the build was skipped.

Made with [Cursor](https://cursor.com)