### PR TITLE
fix(network-ee): unpin ncclient to allow wheel install

### DIFF
--- a/network-ee/requirements.txt
+++ b/network-ee/requirements.txt
@@ -36,7 +36,7 @@ lxml
 MarkupSafe
 multidict
 munch
-ncclient==0.6.13
+ncclient>=0.6.13
 netaddr
 netifaces
 ntlm-auth


### PR DESCRIPTION
ncclient==0.6.13 only has a source tarball. With ansible-builder 3.1+ build isolation, setuptools isn't available to run setup.py. Unpin to >=0.6.13 so pip can use a newer version with a proper wheel.

Made with [Cursor](https://cursor.com)