### PR TITLE
fix(network-ee): use ee-supported base image for ansible-core

### DIFF
--- a/network-ee/execution-environment.yml
+++ b/network-ee/execution-environment.yml
@@ -2,7 +2,7 @@
 version: 3
 images:
   base_image:
-    name: 'registry.redhat.io/ansible-automation-platform-26/ee-minimal-rhel9:latest'
+    name: 'registry.redhat.io/ansible-automation-platform-26/ee-supported-rhel9:latest'
 
 additional_build_files:
     # Can be used to resolve collections from private automation hub
@@ -13,9 +13,6 @@ dependencies:
   galaxy: requirements.yml
   python: requirements.txt
   system: bindep.txt
-  exclude:
-    python:
-      - ansible-core
 
 options:
     package_manager_path: /usr/bin/microdnf

--- a/network-ee/requirements.txt
+++ b/network-ee/requirements.txt
@@ -36,7 +36,7 @@ lxml
 MarkupSafe
 multidict
 munch
-ncclient>=0.6.13
+ncclient==0.6.13
 netaddr
 netifaces
 ntlm-auth

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-ansible-builder>=3.1.0
+ansible-builder==3.0.0


### PR DESCRIPTION
## Summary
- Switches base image from `ee-minimal-rhel9` to `ee-supported-rhel9:latest` — this image ships `ansible-core` pre-installed, so pip sees `ansible_core>=2.17.0` as already satisfied
- Reverts `ansible-builder` to `==3.0.0` — the 3.1+ upgrade broke build isolation for source-only packages (`ncclient`, `ovirt-engine-sdk-python`)
- Reverts `ncclient` pin to `==0.6.13` (works with ansible-builder 3.0.0)
- Removes the `exclude` block (not needed with ee-supported, not supported in 3.0.0)

## Context
The `ee-minimal` image doesn't include ansible-core. Collections pinned to `ansible.controller>=4.6.2` and `ansible.platform>=2.5.3` require `ansible_core>=2.17.0`, which has no Python 3.9 wheel on PyPI. Using `ee-supported` pre-satisfies this dependency via RPM.

Retains the `ansible-pylibssh>=1.2.2` and `setuptools>=65,<81` fixes from earlier PRs for the original `pkg_resources` deprecation warning.

Made with [Cursor](https://cursor.com)