### PR TITLE
fix(network-ee): disable pip build isolation for source packages

### DIFF
--- a/network-ee/execution-environment.yml
+++ b/network-ee/execution-environment.yml
@@ -19,7 +19,8 @@ options:
 
 additional_build_steps:
     prepend_base:
-        - RUN $PYCMD -m pip install --upgrade pip 'setuptools>=65,<81'
+        - RUN $PYCMD -m pip install --upgrade pip 'setuptools>=65,<81' wheel
+        - ENV PIP_NO_BUILD_ISOLATION=1
     prepend_galaxy:
         # Add custom ansible.cfg which defines collection install sources
         - ADD _build/configs/ansible.cfg /etc/ansible/ansible.cfg


### PR DESCRIPTION
pip 26 (from the prepend_base upgrade) enforces build isolation, which breaks source-only packages like systemd-python that need setuptools. Sets PIP_NO_BUILD_ISOLATION=1 so pip uses the globally installed setuptools.

Made with [Cursor](https://cursor.com)