### PR TITLE
fix(network-ee): add systemd-devel for systemd-python build

### DIFF
--- a/network-ee/bindep.txt
+++ b/network-ee/bindep.txt
@@ -5,6 +5,10 @@ libxslt-devel [platform:rpm]     # sometimes required by ovirt/lxml stack
 # Needed so /usr/bin/python3 has pip after microdnf changes the default
 python3-pip [platform:rhel-9]
 
+# Needed for systemd-python C extension (from ansible.eda in ee-supported)
+systemd-devel  [platform:rpm]
+pkgconf        [platform:rpm]
+
 # RHEL/UBI
 python3-devel [platform:rpm]
 krb5-devel     [platform:rpm]


### PR DESCRIPTION
Adds systemd-devel and pkgconf to bindep.txt. systemd-python (required by ansible.eda in the ee-supported base image) is a C extension that needs libsystemd headers to compile.

Made with [Cursor](https://cursor.com)