### PR TITLE
fix(network-ee): install ansible-core 2.17+ from public PyPI in prepend_base

### DIFF
--- a/network-ee/execution-environment.yml
+++ b/network-ee/execution-environment.yml
@@ -20,6 +20,7 @@ options:
 additional_build_steps:
     prepend_base:
         - RUN $PYCMD -m pip install --upgrade pip 'setuptools>=65,<81' wheel
+        - RUN $PYCMD -m pip install --index-url https://pypi.org/simple/ 'ansible-core>=2.17.0'
         - ENV PIP_NO_BUILD_ISOLATION=1
     prepend_galaxy:
         # Add custom ansible.cfg which defines collection install sources

--- a/network-ee/requirements.txt
+++ b/network-ee/requirements.txt
@@ -2,7 +2,6 @@ pip>=23.2
 setuptools>=65,<81
 wheel>=0.40
 aiohttp
-ansible-core>=2.17.0
 ansible-pylibssh>=1.2.2
 argcomplete
 asn1crypto


### PR DESCRIPTION
The ee-supported-rhel9 image's pip config restricts the index to a Red Hat mirror that only has ansible-core up to 2.15.13. Installs 2.17+ from public PyPI in prepend_base so it's already satisfied before the assemble script runs.

Made with [Cursor](https://cursor.com)