### PR TITLE
fix(network-ee): bootstrap pip in builder stage

### DIFF
--- a/network-ee/execution-environment.yml
+++ b/network-ee/execution-environment.yml
@@ -17,6 +17,8 @@ options:
     package_manager_path: /usr/bin/microdnf
 
 additional_build_steps:
+    prepend_base:
+        - RUN $PYCMD -m ensurepip
     prepend_galaxy:
         - ADD _build/configs/ansible.cfg /etc/ansible/ansible.cfg
         - ARG AH_TOKEN


### PR DESCRIPTION
The ee-supported base image doesn't have pip on the default python path. Uses ensurepip to bootstrap it without upgrading from PyPI.

Made with [Cursor](https://cursor.com)