### PR TITLE
fix(network-ee): restore python3-pip in bindep.txt

### DIFF
--- a/network-ee/bindep.txt
+++ b/network-ee/bindep.txt
@@ -1,3 +1,6 @@
+# Needed so /usr/bin/python3 has pip after microdnf changes the default
+python3-pip [platform:rhel-9]
+
 # Needed for ovirt_engine_sdk_python C extension
 libxml2-devel [platform:rpm]
 libxslt-devel [platform:rpm]


### PR DESCRIPTION
microdnf system installs break the python3 pip module. Restores python3-pip that was accidentally removed in the refactor.

Made with [Cursor](https://cursor.com)