### PR TITLE
fix(network-ee): restore systemd-devel for systemd-python

### DIFF
--- a/network-ee/bindep.txt
+++ b/network-ee/bindep.txt
@@ -1,6 +1,10 @@
 # Needed so /usr/bin/python3 has pip after microdnf changes the default
 python3-pip [platform:rhel-9]
 
+# Needed for systemd-python C extension (from ansible.eda in ee-supported)
+systemd-devel  [platform:rpm]
+pkgconf        [platform:rpm]
+
 # Needed for ovirt_engine_sdk_python C extension
 libxml2-devel [platform:rpm]
 libxslt-devel [platform:rpm]


### PR DESCRIPTION
Restores systemd-devel and pkgconf removed in the refactor. ansible.eda in the base image requires systemd-python which needs these headers.

Made with [Cursor](https://cursor.com)