### PR TITLE
fix(network-ee): suppress collection version mismatch warnings

### DIFF
--- a/network-ee/execution-environment.yml
+++ b/network-ee/execution-environment.yml
@@ -19,6 +19,7 @@ options:
 additional_build_steps:
     prepend_base:
         - RUN $PYCMD -m ensurepip
+        - ENV ANSIBLE_COLLECTIONS_ON_ANSIBLE_VERSION_MISMATCH=ignore
     prepend_galaxy:
         - ADD _build/configs/ansible.cfg /etc/ansible/ansible.cfg
         - ARG AH_TOKEN


### PR DESCRIPTION
ee-supported-rhel9 ships collections certified for 2.17+ with ansible-core 2.15.x. They work fine but warn. Sets ANSIBLE_COLLECTIONS_ON_ANSIBLE_VERSION_MISMATCH=ignore so students don't see confusing output.

Made with [Cursor](https://cursor.com)