### PR TITLE
fix(network-ee): move version mismatch suppression to ansible.cfg

### DIFF
--- a/network-ee/ansible.cfg
+++ b/network-ee/ansible.cfg
@@ -1,3 +1,6 @@
+[defaults]
+collections_on_ansible_version_mismatch = ignore
+
 [galaxy]
 server_list = automation_hub, automation_hub_validated, release_galaxy
 

--- a/network-ee/execution-environment.yml
+++ b/network-ee/execution-environment.yml
@@ -19,7 +19,6 @@ options:
 additional_build_steps:
     prepend_base:
         - RUN $PYCMD -m ensurepip
-        - ENV ANSIBLE_COLLECTIONS_ON_ANSIBLE_VERSION_MISMATCH=ignore
     prepend_galaxy:
         - ADD _build/configs/ansible.cfg /etc/ansible/ansible.cfg
         - ARG AH_TOKEN


### PR DESCRIPTION
## Summary
- Moves `collections_on_ansible_version_mismatch = ignore` from an `ENV` var in the Containerfile to the `[defaults]` section of `ansible.cfg`
- Our custom `ansible.cfg` replaces the stock `ee-supported-rhel9` config which already ships this setting — adding it to our config is the proper fix rather than relying on an env var override
- Removes the `ENV ANSIBLE_COLLECTIONS_ON_ANSIBLE_VERSION_MISMATCH=ignore` line from `execution-environment.yml`

## Root cause
The stock `ee-supported-rhel9` image suppresses collection/ansible-core version mismatch warnings via its default `ansible.cfg`. Our build replaces that config (to set galaxy server URLs) but was missing the `[defaults]` section, re-enabling warnings for the same pre-installed collections.

## Test plan
- [ ] Build succeeds in GitHub Actions
- [ ] Run `ansible-navigator run playbook.yml --mode stdout` with the new image — no collection version warnings

Made with [Cursor](https://cursor.com)