### PR TITLE
fix(network-ee): restore ENV var for collection version mismatch suppression

### DIFF
--- a/network-ee/execution-environment.yml
+++ b/network-ee/execution-environment.yml
@@ -19,6 +19,7 @@ options:
 additional_build_steps:
     prepend_base:
         - RUN $PYCMD -m ensurepip
+        - ENV ANSIBLE_COLLECTIONS_ON_ANSIBLE_VERSION_MISMATCH=ignore
     prepend_galaxy:
         - ADD _build/configs/ansible.cfg /etc/ansible/ansible.cfg
         - ARG AH_TOKEN


### PR DESCRIPTION
## Summary
- Restores `ENV ANSIBLE_COLLECTIONS_ON_ANSIBLE_VERSION_MISMATCH=ignore` in `prepend_base`
- PR #86 moved this to `ansible.cfg`, but the `ADD` lives in `prepend_galaxy` (stage 2/4 of the ansible-builder build) — only `/usr/share/ansible` is copied from that stage to the final image, so the config never made it to runtime

## Root cause
`ansible-builder` v3 uses a 4-stage build. Only `prepend_base` (stage 1) persists into the final image. `prepend_galaxy` (stage 2) is used for collection installs then discarded. The ENV var is the correct mechanism to set runtime config from `prepend_base`.

## Test plan
- [ ] Build succeeds
- [ ] `podman pull quay.io/acme_corp/network-ee:latest && ansible-navigator run playbook.yml --mode stdout` — no collection version warnings

Made with [Cursor](https://cursor.com)