### PR TITLE
fix(network-ee): add libssh publickey_algorithms + cursor skill

### DIFF
--- a/.cursor/rules/ee-build-conventions.mdc
+++ b/.cursor/rules/ee-build-conventions.mdc
@@ -6,46 +6,42 @@ alwaysApply: false
 
 # Execution Environment Build Conventions
 
+## ansible-builder v3 Multi-Stage Build (Critical)
+
+ansible-builder v3 generates a 4-stage Containerfile. Only stages 1 and 4 persist into the final image:
+
+- **Stage 1 (base)**: `prepend_base` / `append_base` — **persists** as the final image foundation
+- **Stage 2 (galaxy)**: `prepend_galaxy` / `append_galaxy` — **discarded** (only `/usr/share/ansible` copied out)
+- **Stage 3 (builder)**: `prepend_builder` / `append_builder` — **discarded** (only `/output/` copied out)
+- **Stage 4 (final)**: `prepend_final` / `append_final` — **persists** as the shipped image
+
+**Key implication**: Files added via `ADD` in `prepend_galaxy` (like `ansible.cfg`) do NOT exist in the final image. Use `ENV` in `prepend_base` or `ADD` in `prepend_final`/`append_final` for runtime config.
+
 ## Base Image Selection
 
-- `ee-minimal-rhel9` does NOT include `ansible-core`. If collections require `ansible-core>=2.17.0`, pip will fail on Python 3.9 because PyPI has no 3.9-compatible wheel for 2.17+.
-- `ee-supported-rhel9` includes `ansible-core` pre-installed via RPM (and Python 3.12). Pip sees it as already satisfied. Use this when collections pin `ansible-core>=2.17`.
-- `ee-supported` also bundles extra collections (e.g. `ansible.eda`) whose dependencies (like `systemd-python`) need system headers in `bindep.txt`.
-- Prefer `:latest` tag over SHA digest pins unless reproducibility is critical — stale SHAs cause hard-to-debug Python version mismatches.
+- `ee-minimal-rhel9`: Python 3.9, no `ansible-core`. Fails if collections require `ansible-core>=2.17.0`.
+- `ee-supported-rhel9`: Python 3.12, `ansible-core 2.15.x` via RPM, bundled collections. Work **with** the base — only add delta collections/packages not already present.
+- Prefer `:latest` tag over SHA digest pins unless reproducibility is critical.
 
-## pip Build Isolation (Critical)
+## pip Build Isolation
 
-Upgrading pip in `prepend_base` pulls in pip 26+, which enforces build isolation. Source-only packages (`ncclient`, `ovirt-engine-sdk-python`, `systemd-python`) fail with `No module named 'setuptools'` because the isolated build venv doesn't include it.
-
-**Fix**: Set `ENV PIP_NO_BUILD_ISOLATION=1` in `prepend_base` right after the pip/setuptools upgrade:
-
-```yaml
-prepend_base:
-    - RUN $PYCMD -m pip install --upgrade pip 'setuptools>=65,<81' wheel
-    - ENV PIP_NO_BUILD_ISOLATION=1
-```
-
-## setuptools Version Cap
-
-Cap setuptools below 81 (`setuptools>=65,<81`) in both `requirements.txt` AND `prepend_base`. Setuptools 81+ deprecated `pkg_resources`, which older packages (like `ansible-pylibssh<1.2.2`) import at runtime, producing noisy warnings during playbook execution.
-
-## ansible-builder Version
-
-The CI pins `ansible-builder==3.0.0` in the root `requirements.txt`. The `exclude` keyword under `dependencies` requires `>=3.1.0` but that version changed build isolation behavior and broke source-only packages. Don't upgrade without also addressing build isolation.
+`ansible-builder >=3.1` ships pip 26+ which enforces PEP 517 build isolation. Source-only packages fail with `No module named 'setuptools'`. This repo pins `ansible-builder==3.0.0` to avoid the issue. Don't upgrade without addressing build isolation.
 
 ## Common bindep.txt Entries for ee-supported
 
 When using `ee-supported-rhel9`, these system packages are needed for collection dependencies:
 
 ```
-systemd-devel  [platform:rpm]   # systemd-python (from ansible.eda)
-pkgconf        [platform:rpm]   # pkg-config for C extension builds
-libxml2-devel  [platform:rpm]   # ovirt-engine-sdk-python / lxml
-python3-devel  [platform:rpm]   # any C extension compilation
-gcc            [platform:rpm]   # compiler for C extensions
+python3-pip    [platform:rhel-9] # microdnf can remove pip
+systemd-devel  [platform:rpm]    # systemd-python (from ansible.eda)
+pkgconf        [platform:rpm]    # pkg-config for C extension builds
+libxml2-devel  [platform:rpm]    # ovirt-engine-sdk-python / lxml
+libxslt-devel  [platform:rpm]    # ovirt-engine-sdk-python
+python3-devel  [platform:rpm]    # any C extension compilation
+gcc            [platform:rpm]    # compiler for C extensions
 ```
 
 ## CI Workflow Gotchas
 
-- The `generate_matrix.py` script only builds EEs whose directories changed between `HEAD^1` and `HEAD`. If you change only root-level files (like `requirements.txt`), the EE build is skipped. Touch a file inside the EE directory to trigger it.
+- `generate_matrix.py` only builds EEs whose directories changed between `HEAD^1` and `HEAD`. Touch a file inside the EE directory to force a build.
 - Automation hub 504 timeouts are transient — just rerun the workflow.

--- a/.cursor/rules/network-ee.mdc
+++ b/.cursor/rules/network-ee.mdc
@@ -10,22 +10,20 @@ alwaysApply: false
 
 Used by the Ansible Network Automation Workshop (rhpds/zt-network-automation-workshop). Students see all output, so warnings in playbook runs are confusing and should be eliminated.
 
-## pkg_resources Deprecation Warning (Fixed)
+## Base Image: ee-supported-rhel9
 
-`ansible-pylibssh<1.2.2` imports `pkg_resources` at runtime, producing:
-```
-/usr/lib64/python3.9/site-packages/pylibsshext/_version.py:15: UserWarning: pkg_resources is deprecated as an API.
-```
-**Fix**: Pin `ansible-pylibssh>=1.2.2` (uses `importlib.metadata` instead).
+Collections require `ansible-core>=2.17.0`. `ee-minimal-rhel9` (Python 3.9) can't satisfy this. `ee-supported-rhel9` (Python 3.12, ansible-core 2.15.x RPM) works with pre-bundled collections.
 
-## Why ee-supported Instead of ee-minimal
+## Delta-Only Dependencies
 
-Collections `ansible.controller>=4.6.2` and `ansible.platform>=2.5.3` require `ansible-core>=2.17.0`. The `ee-minimal-rhel9` image has Python 3.9 where ansible-core 2.17+ cannot be pip-installed (no PyPI wheel). The `ee-supported-rhel9` image ships ansible-core via RPM on Python 3.12, satisfying the requirement.
+`requirements.yml` and `requirements.txt` contain ONLY what's not already in the base image. Core collections (`cisco.ios`, `arista.eos`, `ansible.netcommon`, `ansible.utils`, `ansible.controller`, etc.) ship with `ee-supported-rhel9` — do NOT override them or you'll get version conflicts.
 
-## ncclient Pin
+## Collection Version Mismatch Warnings (Fixed)
 
-`ncclient==0.6.13` is pinned because it's the last version validated with the Juniper/Cisco/Arista collection stack in this workshop. Don't unpin without testing network module compatibility.
+The base image's collections declare support for ansible-core >=2.17 but the image ships 2.15.x. Red Hat suppresses the resulting warnings in the stock image's ansible.cfg. Our custom ansible.cfg (used for galaxy server URLs during build) replaces the stock one in the galaxy stage, but that stage is discarded — so the stock suppression survives in the final image.
 
-## Collections
+If warnings reappear, set `ENV ANSIBLE_COLLECTIONS_ON_ANSIBLE_VERSION_MISMATCH=ignore` in `prepend_base` (persists to the final image). Do NOT rely on ansible.cfg changes in `prepend_galaxy` — that stage is thrown away.
 
-Core network collections: `cisco.ios`, `arista.eos`, `junipernetworks.junos`, `ansible.netcommon`, `ansible.utils`. Also includes `ansible.controller` and `ansible.platform` for AAP integration.
+## ansible.cfg
+
+The `ansible.cfg` in this directory configures Automation Hub galaxy servers. It is `ADD`ed in `prepend_galaxy` and used only during `ansible-galaxy collection install`. It does **not** exist in the final runtime image (see multi-stage build notes in ee-build-conventions rule).

--- a/.cursor/skills/ansible-ee-builds/SKILL.md
+++ b/.cursor/skills/ansible-ee-builds/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: ansible-ee-builds
+description: >-
+  Build and troubleshoot Ansible Execution Environments using ansible-builder v3.
+  Use when editing execution-environment.yml, requirements.yml, requirements.txt,
+  bindep.txt, ansible.cfg, or debugging EE build failures and runtime warnings.
+---
+
+# Ansible Execution Environment Builds
+
+## ansible-builder v3 Multi-Stage Build (Critical)
+
+`ansible-builder` v3 generates a **4-stage** Containerfile. Understanding which
+stage persists into the final image is essential:
+
+| Stage | Name | `additional_build_steps` key | Persists to final image? |
+|-------|------|------------------------------|--------------------------|
+| 1/4 | **base** | `prepend_base` / `append_base` | **YES** — this IS the final image's foundation |
+| 2/4 | **galaxy** | `prepend_galaxy` / `append_galaxy` | **NO** — only `/usr/share/ansible` is copied out |
+| 3/4 | **builder** | `prepend_builder` / `append_builder` | **NO** — only `/output/` (wheels) is copied out |
+| 4/4 | **final** | `prepend_final` / `append_final` | **YES** — this is the shipped image |
+
+### What this means in practice
+
+- **ENV vars** set in `prepend_base` persist into the runtime image.
+- **Files added** in `prepend_galaxy` (e.g. `ADD ansible.cfg`) are **discarded**
+  after collection install. The final image gets the base image's original files.
+- To bake a file into the final image, use `prepend_final` / `append_final`,
+  NOT `prepend_galaxy`.
+
+### Common mistake
+
+```yaml
+# WRONG — ansible.cfg is lost after stage 2
+prepend_galaxy:
+    - ADD _build/configs/ansible.cfg /etc/ansible/ansible.cfg
+
+# RIGHT — ENV in prepend_base persists to runtime
+prepend_base:
+    - ENV ANSIBLE_COLLECTIONS_ON_ANSIBLE_VERSION_MISMATCH=ignore
+```
+
+## Base Image Selection
+
+| Image | Python | ansible-core | Use when |
+|-------|--------|-------------|----------|
+| `ee-minimal-rhel9` | 3.9 | Not included | Collections don't need ansible-core >=2.17 |
+| `ee-supported-rhel9` | 3.12 | 2.15.x (RPM) | Collections need newer ansible-core or you want pre-bundled collections |
+
+- `ee-supported-rhel9` ships many collections pre-installed. Work **with** the
+  base image — only add delta collections in `requirements.yml`.
+- Prefer `:latest` tag over SHA pins unless reproducibility is critical.
+
+## Working with ee-supported: Delta-Only Dependencies
+
+The `ee-supported-rhel9` base ships collections and their Python deps pre-installed.
+Overriding them causes version conflicts and runtime warnings.
+
+### requirements.yml strategy
+
+Only list collections **not** already in the base image:
+
+```yaml
+collections:
+  - name: cisco.asa          # not in ee-supported
+  - name: containers.podman  # not in ee-supported
+  # Do NOT add cisco.ios, ansible.netcommon, etc. — they ship with the base
+```
+
+Check what's already installed by running:
+```bash
+podman run --rm <base-image> ansible-galaxy collection list
+```
+
+### requirements.txt strategy
+
+Only list Python packages the delta collections need that aren't already
+satisfied by the base image's bundled deps.
+
+## ansible.cfg and the Galaxy Stage
+
+The `ansible.cfg` is added in `prepend_galaxy` so that `ansible-galaxy install`
+can reach Automation Hub. This file is **only used during build** — it does not
+survive to the final image (see stage table above).
+
+If you need Ansible config settings at runtime, use one of:
+1. `ENV` in `prepend_base` (simplest, most reliable)
+2. `ADD` in `prepend_final` or `append_final`
+
+## pip Build Isolation
+
+`ansible-builder >=3.1` ships pip 26+ which enforces PEP 517 build isolation.
+Source-only packages (`ncclient`, `ovirt-engine-sdk-python`, `systemd-python`)
+fail with `No module named 'setuptools'`.
+
+**Workaround**: Either pin `ansible-builder==3.0.0` (avoids the issue) or set
+`ENV PIP_NO_BUILD_ISOLATION=1` in `prepend_base`.
+
+This repo pins `ansible-builder==3.0.0` in the root `requirements.txt`.
+
+## bindep.txt for ee-supported
+
+The base image's bundled collections have C-extension deps needing headers:
+
+```
+systemd-devel  [platform:rpm]   # systemd-python (ansible.eda)
+pkgconf        [platform:rpm]   # pkg-config for C builds
+libxml2-devel  [platform:rpm]   # ovirt-engine-sdk-python / lxml
+libxslt-devel  [platform:rpm]   # ovirt-engine-sdk-python
+python3-devel  [platform:rpm]   # any C extension
+gcc            [platform:rpm]   # compiler
+python3-pip    [platform:rhel-9] # microdnf can remove pip; ensure it's present
+```
+
+## CI Workflow Notes
+
+- `generate_matrix.py` only builds EEs whose directories changed between
+  `HEAD^1` and `HEAD`. Touch a file in the EE directory to force a build.
+- Automation Hub 504 timeouts are transient — rerun the workflow.
+- The workflow runs on merge to `main`. Use devel→main PRs.
+
+## Debugging Checklist
+
+When an EE build fails or produces runtime warnings:
+
+1. **Build failure in galaxy stage?** → Check Automation Hub auth tokens, network
+2. **`No module named setuptools`?** → pip build isolation issue (see above)
+3. **`No module named pip`?** → Add `python3-pip` to bindep.txt + `RUN $PYCMD -m ensurepip` in prepend_base
+4. **Collection version warnings at runtime?** → Check if your build overwrites the base image's ansible.cfg; use ENV var in prepend_base instead
+5. **Collections pulling wrong versions?** → You're probably overriding base image collections in requirements.yml; trim to delta only

--- a/network-ee/ansible.cfg
+++ b/network-ee/ansible.cfg
@@ -1,6 +1,9 @@
 [defaults]
 collections_on_ansible_version_mismatch = ignore
 
+[libssh_connection]
+publickey_algorithms = ssh-rsa
+
 [galaxy]
 server_list = automation_hub, automation_hub_validated, release_galaxy
 


### PR DESCRIPTION
## Summary
- Adds `[libssh_connection]` section to `ansible.cfg` with `publickey_algorithms = ssh-rsa`
- Adds ansible-ee-builds cursor skill and updated cursor rules from recent build troubleshooting

## Test plan
- [ ] Build succeeds and pushes to quay.io

Made with [Cursor](https://cursor.com)