### PR TITLE
fix(network-ee): persist ansible.cfg to runtime image for libssh ssh-rsa support

### DIFF
--- a/network-ee/execution-environment.yml
+++ b/network-ee/execution-environment.yml
@@ -25,3 +25,5 @@ additional_build_steps:
         - ARG AH_TOKEN
         - ENV ANSIBLE_GALAXY_SERVER_AUTOMATION_HUB_TOKEN=$AH_TOKEN
         - ENV ANSIBLE_GALAXY_SERVER_AUTOMATION_HUB_VALIDATED_TOKEN=$AH_TOKEN
+    append_final:
+        - ADD _build/configs/ansible.cfg /etc/ansible/ansible.cfg


### PR DESCRIPTION
## Summary
- Adds `append_final` step to copy `ansible.cfg` into the final runtime image (stage 4/4)
- The existing `prepend_galaxy` ADD only lives in the galaxy build stage and is discarded
- Fixes AAP backup job failure on Cisco IOS: `ssh-rsa is not allowed by PUBLICKEY_ACCEPTED_TYPES`

## Root cause
The `[libssh_connection]` section with `publickey_algorithms = ssh-rsa` was added to `ansible.cfg` but only deployed to the galaxy stage. AAP runs inside the final image where this config didn't exist, so libssh rejected `ssh-rsa` keys.

## Test plan
- [ ] Build succeeds
- [ ] AAP backup job template succeeds on rtr1 (Cisco IOS) without ssh-rsa error

Made with [Cursor](https://cursor.com)