### PR TITLE
fix(network-ee): ENV var for libssh ssh-rsa publickey algorithm

### DIFF
--- a/network-ee/execution-environment.yml
+++ b/network-ee/execution-environment.yml
@@ -20,6 +20,7 @@ additional_build_steps:
     prepend_base:
         - RUN $PYCMD -m ensurepip
         - ENV ANSIBLE_COLLECTIONS_ON_ANSIBLE_VERSION_MISMATCH=ignore
+        - ENV ANSIBLE_LIBSSH_PUBLICKEY_ALGORITHMS=ssh-rsa
     prepend_galaxy:
         - ADD _build/configs/ansible.cfg /etc/ansible/ansible.cfg
         - ARG AH_TOKEN


### PR DESCRIPTION
## Summary
- Adds `ENV ANSIBLE_LIBSSH_PUBLICKEY_ALGORITHMS=ssh-rsa` in `prepend_base`
- The `ansible.cfg` `[libssh_connection]` setting doesn't propagate through the `network_cli` -> `libssh` sub-connection chain
- ENV vars in `prepend_base` (stage 1/4) are always visible to all plugins at runtime

## Root cause
The `network_cli` connection plugin spawns libssh as a sub-connection. Config settings from `ansible.cfg` and inventory vars don't reliably propagate to the sub-connection. The `ANSIBLE_LIBSSH_PUBLICKEY_ALGORITHMS` env var is checked directly by the libssh plugin, bypassing the config chain.

## Test plan
- [ ] Build succeeds
- [ ] AAP backup job template succeeds on rtr1 (Cisco IOS) — no ssh-rsa rejection

Made with [Cursor](https://cursor.com)