### PR TITLE
fix(network-ee): relax RHEL 9 crypto policy to allow ssh-rsa for Cisco IOS

### DIFF
--- a/network-ee/execution-environment.yml
+++ b/network-ee/execution-environment.yml
@@ -28,3 +28,4 @@ additional_build_steps:
         - ENV ANSIBLE_GALAXY_SERVER_AUTOMATION_HUB_VALIDATED_TOKEN=$AH_TOKEN
     append_final:
         - ADD _build/configs/ansible.cfg /etc/ansible/ansible.cfg
+        - RUN update-crypto-policies --set DEFAULT:SHA1


### PR DESCRIPTION
## Summary
- Adds `RUN update-crypto-policies --set DEFAULT:SHA1` in `append_final`
- RHEL 9's system crypto policy blocks `ssh-rsa` at the libssh C library level, before any Ansible config is consulted
- All Ansible-level fixes (`ansible.cfg`, ENV vars, host vars) were silently ignored because the OS rejected the algorithm first

## Root cause chain
1. Ansible tells pylibssh to use `ssh-rsa`
2. pylibssh calls the system libssh C library
3. libssh checks RHEL 9's crypto policy (`/etc/crypto-policies/back-ends/libssh.config`)
4. `ssh-rsa` is blocked → error before Ansible sees it

`DEFAULT:SHA1` re-enables SHA1-based algorithms (including `ssh-rsa`) inside the container.

## Test plan
- [ ] Build succeeds
- [ ] AAP backup job template succeeds on rtr1 (Cisco IOS)

Made with [Cursor](https://cursor.com)