### PR TITLE
fix(network-ee): install crypto-policies-scripts for ssh-rsa support

### DIFF
--- a/network-ee/execution-environment.yml
+++ b/network-ee/execution-environment.yml
@@ -28,4 +28,4 @@ additional_build_steps:
         - ENV ANSIBLE_GALAXY_SERVER_AUTOMATION_HUB_VALIDATED_TOKEN=$AH_TOKEN
     append_final:
         - ADD _build/configs/ansible.cfg /etc/ansible/ansible.cfg
-        - RUN update-crypto-policies --set DEFAULT:SHA1
+        - RUN microdnf install -y crypto-policies-scripts && printf '[libssh]\npubkey_algorithms = +ssh-rsa\n[openssh]\nPubkeyAcceptedAlgorithms = +ssh-rsa\nHostKeyAlgorithms = +ssh-rsa\n' > /etc/crypto-policies/policies/modules/ANSIBLE-SSH-RSA.pmod && update-crypto-policies --set DEFAULT:ANSIBLE-SSH-RSA && microdnf clean all


### PR DESCRIPTION
## Summary
- Installs `crypto-policies-scripts` package (provides `update-crypto-policies`)
- Creates custom crypto policy module `ANSIBLE-SSH-RSA` to re-enable `ssh-rsa`
- Previous build failed: `update-crypto-policies: command not found`

## Root cause chain
The ssh-rsa failure on Cisco IOS (rtr1) is at the OS level, not Ansible:
1. Ansible/pylibssh requests ssh-rsa
2. System libssh C library checks RHEL 9 crypto policy
3. `/etc/crypto-policies/back-ends/libssh.config` blocks ssh-rsa
4. Error before any Ansible config is consulted

`DEFAULT:ANSIBLE-SSH-RSA` adds ssh-rsa back to allowed algorithms.

## Test plan
- [ ] Build succeeds
- [ ] AAP backup job template succeeds on rtr1 (Cisco IOS)

Made with [Cursor](https://cursor.com)