### PR TITLE
fix(network-ee): use built-in DEFAULT:SHA1 crypto sub-policy

### DIFF
--- a/network-ee/execution-environment.yml
+++ b/network-ee/execution-environment.yml
@@ -28,4 +28,4 @@ additional_build_steps:
         - ENV ANSIBLE_GALAXY_SERVER_AUTOMATION_HUB_VALIDATED_TOKEN=$AH_TOKEN
     append_final:
         - ADD _build/configs/ansible.cfg /etc/ansible/ansible.cfg
-        - RUN microdnf install -y crypto-policies-scripts && printf '[libssh]\npubkey_algorithms = +ssh-rsa\n[openssh]\nPubkeyAcceptedAlgorithms = +ssh-rsa\nHostKeyAlgorithms = +ssh-rsa\n' > /etc/crypto-policies/policies/modules/ANSIBLE-SSH-RSA.pmod && update-crypto-policies --set DEFAULT:ANSIBLE-SSH-RSA && microdnf clean all
+        - RUN microdnf install -y crypto-policies-scripts && update-crypto-policies --set DEFAULT:SHA1 && microdnf clean all


### PR DESCRIPTION
## Summary
- Replaces malformed custom `.pmod` file with built-in `DEFAULT:SHA1` sub-policy
- Previous build failed: `.pmod` used INI syntax but crypto-policies modules use a different format

## Test plan
- [ ] Build succeeds  
- [ ] AAP backup job on rtr1 (Cisco IOS) no longer fails with ssh-rsa error

Made with [Cursor](https://cursor.com)