### PR TITLE
Demo: test-preflight-ee with intentional issues

### DIFF
--- a/test-preflight-ee/bindep.txt
+++ b/test-preflight-ee/bindep.txt
@@ -1,0 +1,1 @@
+pkgconf-pkg-config [platform:rpm]

--- a/test-preflight-ee/execution-environment.yml
+++ b/test-preflight-ee/execution-environment.yml
@@ -1,0 +1,35 @@
+---
+version: 3
+
+# BUG 1: Stray root-level collections key — silently ignored in EE v3.
+# ansible-builder won't install these. Build succeeds, EE is broken at runtime.
+collections:
+  - name: ansible.posix
+  - name: community.general
+
+images:
+  base_image:
+    name: registry.redhat.io/ansible-automation-platform-25/ee-minimal-rhel8:latest
+
+dependencies:
+    galaxy: requirements.yml
+    python: python-packages.txt
+    # BUG 2: Missing system deps — libssh-devel needed by ncclient/ansible.netcommon
+    # ansible-builder only catches this as a wall of gcc errors during wheel compile
+    system: bindep.txt
+
+additional_build_files:
+    - src: ansible.cfg
+      dest: configs
+
+options:
+    package_manager_path: /usr/bin/microdnf
+
+additional_build_steps:
+    prepend_base:
+        - ENV PIP_IGNORE_INSTALLED=1
+        - RUN $PYCMD -m pip install --upgrade pip setuptools
+    prepend_galaxy:
+        - ADD _build/configs/ansible.cfg /etc/ansible/ansible.cfg
+        - ARG AH_TOKEN
+        - ENV ANSIBLE_GALAXY_SERVER_AUTOMATION_HUB_TOKEN=$AH_TOKEN

--- a/test-preflight-ee/python-packages.txt
+++ b/test-preflight-ee/python-packages.txt
@@ -1,0 +1,4 @@
+jmespath
+pytz
+pynetbox
+ncclient

--- a/test-preflight-ee/requirements.yml
+++ b/test-preflight-ee/requirements.yml
@@ -1,0 +1,10 @@
+---
+collections:
+  - name: netbox.netbox
+    version: 3.22.0
+  - name: community.general
+  - name: ansible.netcommon
+  - name: ansible.utils
+  - name: ansible.posix
+  - name: arista.eos
+  - name: cisco.ios


### PR DESCRIPTION
## Summary

Test EE to demo ee-preflight CI catching issues that ansible-builder either misses or reports cryptically.

### Intentional bugs

1. **Stray root-level `collections` key** — In EE v3, this is silently ignored by ansible-builder. Build succeeds but the collections listed here are never installed. The EE breaks at runtime. Preflight warns about this in Layer 0.

2. **Missing system deps in bindep.txt** — `ncclient` (from `ansible.netcommon`) needs `libssh-devel` to compile, but it's not in bindep.txt. ansible-builder catches this only as a wall of gcc errors during wheel compilation inside the container. Preflight catches it in Layer 2 with a clear message and fix suggestion.

### Expected preflight results

- Layer 0: Stray collections warning + YAML indentation warnings
- Layer 1: Pass (collections resolve fine)
- Layer 2: Missing system dep error for libssh-devel

**Do not merge** — close after verifying results.