### PR TITLE
Add amazon.aws collection to netbox-summit-2026-ee

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,4 @@ ansible.cfg
 .lock
 .venv
 **/.vscode
-**/.devcontainer
-**/devcontainer.json
+tmp/

--- a/netbox-summit-2026-ee/ansible-collections.yml
+++ b/netbox-summit-2026-ee/ansible-collections.yml
@@ -32,6 +32,9 @@ collections:
   - name: junipernetworks.junos
     version: 11.1.1
 
+  ## cloud collections
+  - name: amazon.aws
+
   ## platform collections
   - name: containers.podman
     version: 1.19.2


### PR DESCRIPTION
## Summary
- Add amazon.aws collection to netbox-summit-2026-ee
- Update .gitignore: add tmp/, remove devcontainer entries

## Test plan
- [ ] CI builds the EE successfully with the new collection
- [ ] Verify amazon.aws modules are available in the built image