### PR TITLE
Add tag-ee-image workflow for quay.io version tagging

### DIFF
--- a/.github/workflows/pr-ee-preflight.yml
+++ b/.github/workflows/pr-ee-preflight.yml
@@ -1,0 +1,196 @@
+name: EE Preflight Check
+
+on:
+  pull_request_target:
+    branches:
+      - main
+    types: [opened, reopened, synchronize]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  prepare-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+      length: ${{ steps.set-matrix.outputs.length }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Generate matrix
+        id: generate-matrix
+        run: |
+          python -u .github/workflows/generate_matrix.py \
+            --start-ref origin/$GITHUB_BASE_REF \
+            --end-ref $GITHUB_HEAD_REF \
+            --output-path matrix_output.json
+
+      - name: Read matrix
+        id: set-matrix
+        run: |
+          MATRIX_JSON=$(cat matrix_output.json)
+          echo "matrix=$MATRIX_JSON" >> "$GITHUB_OUTPUT"
+          MATRIX_LENGTH=$(echo "$MATRIX_JSON" | jq '.include | length')
+          echo "length=$MATRIX_LENGTH" >> "$GITHUB_OUTPUT"
+
+  preflight:
+    needs: [prepare-matrix]
+    if: ${{ needs.prepare-matrix.outputs.length != '0' }}
+    runs-on: ubuntu-latest
+    environment: test
+    strategy:
+      matrix: ${{ fromJson(needs.prepare-matrix.outputs.matrix) }}
+      fail-fast: false
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.ref != '' && github.event.pull_request.head.ref || 'main' }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install ee-preflight
+        run: pip install git+https://github.com/leogallego/ee-preflight.git@main
+
+      - name: Substitute token for automation hub
+        run: |
+          sed -i "s/my_ah_token/${{ secrets.AH_TOKEN }}/g" ansible.cfg
+
+      - name: Run ee-preflight
+        id: preflight
+        working-directory: ${{ matrix.ee }}
+        env:
+          AH_TOKEN: ${{ secrets.AH_TOKEN }}
+        run: |
+          set +e
+          ee-preflight execution-environment.yml --json > preflight-result.json 2>&1
+          EXIT_CODE=$?
+          set -e
+
+          echo "exit_code=$EXIT_CODE" >> "$GITHUB_OUTPUT"
+
+          # Human-readable output for the log
+          echo "## ee-preflight: ${{ matrix.ee }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          if [ "$EXIT_CODE" -eq 0 ]; then
+            echo "Result: PASS" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "Result: FAIL" >> "$GITHUB_STEP_SUMMARY"
+          fi
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo '```json' >> "$GITHUB_STEP_SUMMARY"
+          cat preflight-result.json >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+          # Also print to log for quick visibility
+          cat preflight-result.json | python -m json.tool 2>/dev/null || cat preflight-result.json
+
+          exit $EXIT_CODE
+
+      - name: Upload preflight artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: preflight-${{ matrix.ee }}
+          path: ${{ matrix.ee }}/preflight-result.json
+
+  post-preflight-comment:
+    needs: [prepare-matrix, preflight]
+    if: always() && needs.prepare-matrix.outputs.length != '0'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: preflight-*
+
+      - name: Build and post comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            const MARKER = '<!-- ee-preflight-results -->';
+
+            let body = MARKER + '\n';
+            body += '### ee-preflight results\n\n';
+
+            const sha = context.payload.pull_request?.head?.sha || context.sha;
+            body += `Commit: \`${sha.substring(0, 7)}\`\n\n`;
+
+            const dirs = fs.readdirSync('.', { withFileTypes: true })
+              .filter(d => d.isDirectory() && d.name.startsWith('preflight-'))
+              .sort((a, b) => a.name.localeCompare(b.name));
+
+            for (const dir of dirs) {
+              const files = fs.readdirSync(dir.name);
+              for (const file of files) {
+                const filePath = path.join(dir.name, file);
+                const eeName = dir.name.replace('preflight-', '');
+
+                let content;
+                try {
+                  content = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+                } catch (e) {
+                  body += `**${eeName}**: failed to parse results\n\n`;
+                  continue;
+                }
+
+                const passed = content.result === 'pass';
+                const icon = passed ? '✅' : '❌';
+                body += `${icon} **${eeName}**\n\n`;
+
+                for (const layer of (content.layers || [])) {
+                  const findings = (layer.findings || []).filter(f => f.severity !== 'info');
+                  if (findings.length === 0) continue;
+
+                  body += `<details>\n<summary>${layer.name} (${findings.length} finding(s))</summary>\n\n`;
+                  for (const f of findings) {
+                    const sev = f.severity === 'error' ? '❌' : '⚠️';
+                    body += `- ${sev} ${f.message}\n`;
+                    if (f.fix) body += `  - Fix: \`${f.fix}\`\n`;
+                  }
+                  body += `\n</details>\n\n`;
+                }
+              }
+            }
+
+            if (dirs.length === 0) {
+              body += '_No preflight results found._\n';
+            }
+
+            // Find existing preflight comment by hidden marker
+            const prNumber = context.issue.number;
+            const { data: comments } = await github.rest.issues.listComments({
+              ...context.repo,
+              issue_number: prNumber,
+            });
+            const existing = comments.find(c => c.body && c.body.includes(MARKER));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                ...context.repo,
+                comment_id: existing.id,
+                body: body.trim(),
+              });
+            } else {
+              await github.rest.issues.createComment({
+                ...context.repo,
+                issue_number: prNumber,
+                body: body.trim(),
+              });
+            }

--- a/.github/workflows/tag-ee-image.yml
+++ b/.github/workflows/tag-ee-image.yml
@@ -1,0 +1,95 @@
+name: Tag EE Image
+
+on:
+  push:
+    tags:
+      - '*/v*'
+  workflow_dispatch:
+    inputs:
+      ee_name:
+        description: 'EE directory name (e.g. netbox-summit-2026-ee)'
+        required: true
+      version:
+        description: 'Version tag without v prefix (e.g. 3.22-3)'
+        required: true
+      commit_sha:
+        description: 'Commit SHA of the image to tag (must already be pushed to quay)'
+        required: true
+
+jobs:
+  tag-image:
+    runs-on: ubuntu-latest
+    environment: deploy
+    steps:
+      - name: Parse tag or inputs
+        env:
+          REF_NAME: ${{ github.ref_name }}
+          INPUT_EE_NAME: ${{ github.event.inputs.ee_name }}
+          INPUT_VERSION: ${{ github.event.inputs.version }}
+          INPUT_SHA: ${{ github.event.inputs.commit_sha }}
+          EVENT_NAME: ${{ github.event_name }}
+          GIT_SHA: ${{ github.sha }}
+        run: |
+          if [ "${EVENT_NAME}" = "workflow_dispatch" ]; then
+            EE_NAME="${INPUT_EE_NAME}"
+            VERSION="${INPUT_VERSION}"
+            COMMIT_SHA="${INPUT_SHA}"
+          else
+            EE_NAME="${REF_NAME%%/v*}"
+            VERSION="${REF_NAME#*/v}"
+            COMMIT_SHA="${GIT_SHA}"
+          fi
+
+          BASE_VERSION="${VERSION%%-*}"
+
+          echo "EE_NAME=${EE_NAME}" >> $GITHUB_ENV
+          echo "VERSION=${VERSION}" >> $GITHUB_ENV
+          echo "BASE_VERSION=${BASE_VERSION}" >> $GITHUB_ENV
+          echo "COMMIT_SHA=${COMMIT_SHA}" >> $GITHUB_ENV
+
+          echo "EE: ${EE_NAME}"
+          echo "Version: ${VERSION}"
+          echo "Base version: ${BASE_VERSION}"
+          echo "Commit SHA: ${COMMIT_SHA}"
+
+      - name: Log in to quay.io
+        uses: redhat-actions/podman-login@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.REDHAT_USERNAME }}
+          password: ${{ secrets.REDHAT_PASSWORD }}
+
+      - name: Tag image with immutable version
+        run: |
+          skopeo copy \
+            "docker://quay.io/${QUAY_USER}/${EE_NAME}:${COMMIT_SHA}" \
+            "docker://quay.io/${QUAY_USER}/${EE_NAME}:v${VERSION}"
+        env:
+          QUAY_USER: ${{ secrets.QUAY_USER }}
+
+      - name: Tag image with floating base version
+        run: |
+          skopeo copy \
+            "docker://quay.io/${QUAY_USER}/${EE_NAME}:${COMMIT_SHA}" \
+            "docker://quay.io/${QUAY_USER}/${EE_NAME}:v${BASE_VERSION}"
+        env:
+          QUAY_USER: ${{ secrets.QUAY_USER }}
+
+      - name: Print summary
+        env:
+          QUAY_USER: ${{ secrets.QUAY_USER }}
+        run: |
+          echo "## Tagged EE Image" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**EE:** ${EE_NAME}" >> $GITHUB_STEP_SUMMARY
+          echo "**Source:** \`quay.io/${QUAY_USER}/${EE_NAME}:${COMMIT_SHA}\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Tags applied:**" >> $GITHUB_STEP_SUMMARY
+          echo "- \`v${VERSION}\` (immutable)" >> $GITHUB_STEP_SUMMARY
+          echo "- \`v${BASE_VERSION}\` (floating)" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Pull commands:**" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          echo "podman pull quay.io/${QUAY_USER}/${EE_NAME}:v${VERSION}" >> $GITHUB_STEP_SUMMARY
+          echo "podman pull quay.io/${QUAY_USER}/${EE_NAME}:v${BASE_VERSION}" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,144 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This repository manages **Ansible Execution Environment (EE) container image definitions** built with `ansible-builder`. Each top-level directory (except `.github/`, `.devcontainer/`, `.vscode/`, `.ansible/`) is a self-contained EE definition. Images are built via GitHub Actions and pushed to **quay.io** (production, on push to `main`). PR builds compile the image but do not push it.
+
+The upstream fork is `ansible-tmm/ee-builds`. This fork (`leogallego/ansible-ee-builds`) adds custom EEs.
+
+## Build Commands
+
+```bash
+# Install ansible-builder (pinned to 3.0.0)
+pip install -r requirements.txt
+
+# Build an EE locally (from repo root)
+ansible-builder build -f <ee-dir>/execution-environment.yml -t <image-name>:latest -v 3
+
+# Build with Automation Hub token (required for certified/validated collections)
+ansible-builder build -f <ee-dir>/execution-environment.yml -t <image-name>:latest -v 3 --build-arg AH_TOKEN=<token>
+
+# Inspect what's already in a base image
+podman run --rm <base-image> ansible-galaxy collection list
+```
+
+The `ansible.cfg` files use `my_ah_token` as a placeholder — CI replaces it via `sed` at build time. For local builds, either edit the placeholder or pass `--build-arg AH_TOKEN=<token>`.
+
+## EE Directory Structure
+
+Each EE directory follows `ansible-builder` conventions. The only required file is `execution-environment.yml`. Other files are referenced from it:
+
+| File | Purpose |
+|------|---------|
+| `execution-environment.yml` | EE definition (version 3 preferred, some legacy v2) |
+| `ansible-collections.yml` or `requirements.yml` | Galaxy collection dependencies |
+| `python-packages.txt` or `requirements.txt` | Python pip dependencies |
+| `bindep.txt` or `system-packages.txt` | System RPM packages |
+| `ansible.cfg` | Galaxy server config with AH token placeholder |
+
+Naming varies across EEs — match the convention of the specific EE you're modifying.
+
+## ansible-builder v3 Multi-Stage Build (Critical)
+
+`ansible-builder` v3 generates a **4-stage Containerfile**. Understanding which stages persist is essential:
+
+| Stage | Name | Build steps key | Persists to final image? |
+|-------|------|-----------------|--------------------------|
+| 1 | **base** | `prepend_base` / `append_base` | **YES** — foundation of the final image |
+| 2 | **galaxy** | `prepend_galaxy` / `append_galaxy` | **NO** — only `/usr/share/ansible` copied out |
+| 3 | **builder** | `prepend_builder` / `append_builder` | **NO** — only `/output/` (wheels) copied out |
+| 4 | **final** | `prepend_final` / `append_final` | **YES** — the shipped image |
+
+**Key implications:**
+- `ENV` vars set in `prepend_base` persist into the runtime image.
+- Files added in `prepend_galaxy` (like `ansible.cfg`) are **discarded** after collection install. The final image gets the base image's original files.
+- To bake a file into the final image, use `prepend_final` / `append_final`.
+
+```yaml
+# WRONG — ansible.cfg is lost after stage 2
+prepend_galaxy:
+    - ADD _build/configs/ansible.cfg /etc/ansible/ansible.cfg
+
+# RIGHT — ENV in prepend_base persists to runtime
+prepend_base:
+    - ENV ANSIBLE_COLLECTIONS_ON_ANSIBLE_VERSION_MISMATCH=ignore
+```
+
+### Standard build steps pattern
+```yaml
+additional_build_steps:
+  prepend_base:
+    - RUN $PYCMD -m pip install --upgrade pip setuptools
+  prepend_galaxy:
+    - ADD _build/configs/ansible.cfg /etc/ansible/ansible.cfg
+    - ARG AH_TOKEN
+    - ENV ANSIBLE_GALAXY_SERVER_AUTOMATION_HUB_TOKEN=$AH_TOKEN
+```
+
+The `prepend_galaxy` block injects `ansible.cfg` and the AH token so `ansible-galaxy` can pull certified/validated collections during the build. This config does NOT survive to the final image.
+
+## Base Image Selection
+
+Images live in `registry.redhat.io/ansible-automation-platform-<aap-version>/`:
+
+| Image | Python | ansible-core | Use when |
+|-------|--------|-------------|----------|
+| `ee-minimal-rhel8/9` | 3.9 | Not included | Collections don't require ansible-core >=2.17 |
+| `ee-supported-rhel8/9` | 3.12 | 2.15.x (RPM) | Collections need newer ansible-core or you want pre-bundled collections |
+| `de-minimal-rhel8` | — | — | Development Environments (not EEs) |
+
+AAP versions: `aap-23` (oldest), `aap-24` (current), `aap-25` (newest). Prefer `:latest` tag over SHA pins unless reproducibility is critical.
+
+### Delta-only dependencies for ee-supported
+
+`ee-supported` ships many collections and Python packages pre-installed. **Only add what's not already in the base image** — overriding bundled deps causes version conflicts and runtime warnings.
+
+```yaml
+# requirements.yml — only delta collections
+collections:
+  - name: cisco.asa          # not in ee-supported
+  # Do NOT add cisco.ios, ansible.netcommon — they ship with the base
+```
+
+## pip Build Isolation
+
+`ansible-builder >=3.1` ships pip 26+ which enforces PEP 517 build isolation. Source-only packages (`ncclient`, `ovirt-engine-sdk-python`, `systemd-python`) fail with `No module named 'setuptools'`. This repo pins `ansible-builder==3.0.0` to avoid the issue. Don't upgrade without addressing build isolation.
+
+## CI/CD Architecture
+
+### Workflows (`.github/workflows/`)
+
+- **`push-ee-build.yml`** — Triggers on push to `main`. Detects changed EE directories via `generate_matrix.py`, builds in parallel, pushes to quay.io with tags `latest` and `{SHA}`. Environment: `deploy`.
+- **`pr-ee-build.yml`** — Triggers on PRs to `main` (`pull_request_target`). Same matrix detection. Builds locally but does **not** push to any registry. Posts a PR comment with installed collections and Ansible version. Environment: `test`.
+- **`generate_matrix.py`** — Compares git refs to find changed directories containing `execution-environment.yml`, outputs a JSON matrix.
+- **`refresh-ah-token.yml`** / **`refresh-token.yml`** — Scheduled (1st and 26th of month) token refresh against Red Hat SSO.
+
+### Required secrets
+- `AH_TOKEN` — Red Hat Automation Hub offline token
+- `REDHAT_SA_USERNAME` / `REDHAT_SA_PASSWORD` — registry.redhat.io service account
+- `REDHAT_USERNAME` / `REDHAT_PASSWORD` — quay.io credentials
+- `QUAY_USER` — quay.io org/user namespace
+
+### How CI detects what to build
+Only EE directories with changed files between the base and head refs are built. No workflow changes needed when adding a new EE — `generate_matrix.py` auto-detects directories with `execution-environment.yml`. Touch a file in an EE directory to force a rebuild. Automation Hub 504 timeouts are transient — just rerun the workflow.
+
+## Adding a New EE
+
+1. Create a new directory at the repo root (name = image name, use lowercase with hyphens or underscores).
+2. Add `execution-environment.yml` (version 3) pointing to the desired base image.
+3. Add dependency files as needed (`requirements.yml`, `requirements.txt`/`python-packages.txt`, `bindep.txt`).
+4. Copy `ansible.cfg` from an existing EE (contains Galaxy server config with `my_ah_token` placeholder).
+5. Add `ansible.cfg` to `additional_build_files` in the EE definition.
+6. No workflow changes needed.
+
+## Debugging EE Builds
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Build failure in galaxy stage | Automation Hub auth | Check AH_TOKEN, network connectivity |
+| `No module named setuptools` | pip build isolation (ansible-builder >=3.1) | Stay on `ansible-builder==3.0.0` or set `ENV PIP_NO_BUILD_ISOLATION=1` in `prepend_base` |
+| `No module named pip` | microdnf removed pip | Add `python3-pip` to `bindep.txt` + `RUN $PYCMD -m ensurepip` in `prepend_base` |
+| Collection version warnings at runtime | Build overwrites base image's ansible.cfg | Use `ENV ANSIBLE_COLLECTIONS_ON_ANSIBLE_VERSION_MISMATCH=ignore` in `prepend_base` (not ansible.cfg in galaxy stage) |
+| Collections pulling wrong versions | Overriding base image collections | Trim `requirements.yml` to delta-only |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,8 +6,6 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 This repository manages **Ansible Execution Environment (EE) container image definitions** built with `ansible-builder`. Each top-level directory (except `.github/`, `.devcontainer/`, `.vscode/`, `.ansible/`) is a self-contained EE definition. Images are built via GitHub Actions and pushed to **quay.io** (production, on push to `main`). PR builds compile the image but do not push it.
 
-The upstream fork is `ansible-tmm/ee-builds`. This fork (`leogallego/ansible-ee-builds`) adds custom EEs.
-
 ## Build Commands
 
 ```bash
@@ -81,15 +79,52 @@ The `prepend_galaxy` block injects `ansible.cfg` and the AH token so `ansible-ga
 
 ## Base Image Selection
 
-Images live in `registry.redhat.io/ansible-automation-platform-<aap-version>/`:
+Images live in `registry.redhat.io/ansible-automation-platform-<aap-version>/`. AAP versions: `24`, `25`, `26` (current). RHEL versions: `rhel8`, `rhel9`, `rhel10` (aap26 only, not yet available). Prefer `:latest` tag over SHA pins unless reproducibility is critical.
 
-| Image | Python | ansible-core | Use when |
-|-------|--------|-------------|----------|
-| `ee-minimal-rhel8/9` | 3.9 | Not included | Collections don't require ansible-core >=2.17 |
-| `ee-supported-rhel8/9` | 3.12 | 2.15.x (RPM) | Collections need newer ansible-core or you want pre-bundled collections |
-| `de-minimal-rhel8` | — | — | Development Environments (not EEs) |
+### ee-minimal (Execution Environments — minimal base)
 
-AAP versions: `aap-23` (oldest), `aap-24` (current), `aap-25` (newest). Prefer `:latest` tag over SHA pins unless reproducibility is critical.
+| AAP | RHEL | ansible-core | Python | Jinja |
+|-----|------|-------------|--------|-------|
+| 24 | rhel8 | 2.16.17 | 3.12.12 | 3.1.6 |
+| 24 | rhel9 | 2.16.17 | 3.12.12 | 3.1.6 |
+| 25 | rhel8 | 2.16.17 | 3.12.12 | 3.1.6 |
+| 25 | rhel9 | 2.16.17 | 3.12.12 | 3.1.6 |
+| 26 | rhel9 | 2.16.18 | 3.12.12 | 3.1.6 |
+
+### ee-supported (Execution Environments — with pre-bundled collections)
+
+| AAP | RHEL | ansible-core | Python | Jinja |
+|-----|------|-------------|--------|-------|
+| 24 | rhel8 | 2.15.12 | 3.9.19 | 3.1.4 |
+| 24 | rhel9 | 2.16.17 | 3.12.12 | 3.1.6 |
+| 25 | rhel8 | 2.16.14 | 3.11.11 | 3.1.6 |
+| 25 | rhel9 | 2.16.17 | 3.12.12 | 3.1.6 |
+| 26 | rhel9 | 2.16.18 | 3.12.12 | 3.1.6 |
+
+### de-minimal (Development Environments — minimal base)
+
+| AAP | RHEL | ansible-core | Python | Jinja |
+|-----|------|-------------|--------|-------|
+| 24 | rhel8 | 2.16.17 | 3.12.12 | 3.1.6 |
+| 24 | rhel9 | 2.16.17 | 3.12.12 | 3.1.6 |
+| 25 | rhel8 | 2.16.17 | 3.12.12 | 3.1.6 |
+| 25 | rhel9 | 2.16.15 | 3.11.13 | 3.1.6 |
+| 26 | rhel9 | 2.16.18 | 3.12.12 | 3.1.6 |
+
+### de-supported (Development Environments — with pre-bundled collections)
+
+| AAP | RHEL | ansible-core | Python | Jinja |
+|-----|------|-------------|--------|-------|
+| 24 | rhel8 | 2.16.17 | 3.12.12 | 3.1.6 |
+| 24 | rhel9 | 2.16.17 | 3.12.12 | 3.1.6 |
+| 25 | rhel8 | 2.16.11 | 3.11.9 | 3.1.4 |
+| 25 | rhel9 | 2.16.14 | 3.11.9 | 3.1.4 |
+| 26 | rhel9 | 2.16.18 | 3.12.12 | 3.1.6 |
+
+**Notes:**
+- aap26 rhel8 images are not available for any image type.
+- aap26 rhel10 images are not yet available (expected future release).
+- ee-supported/de-supported ship pre-bundled collections — only add delta dependencies (see below).
 
 ### Delta-only dependencies for ee-supported
 
@@ -104,7 +139,13 @@ collections:
 
 ## pip Build Isolation
 
-`ansible-builder >=3.1` ships pip 26+ which enforces PEP 517 build isolation. Source-only packages (`ncclient`, `ovirt-engine-sdk-python`, `systemd-python`) fail with `No module named 'setuptools'`. This repo pins `ansible-builder==3.0.0` to avoid the issue. Don't upgrade without addressing build isolation.
+Neither `ansible-builder` 3.0.0 nor 3.1.1 upgrades pip in the generated Containerfile — both just call `ensurepip`, keeping the base image's pip (23.2.1). The build isolation problem only occurs when an EE's own `prepend_base` runs `pip install --upgrade pip`, which upgrades to pip 24+ where PEP 517 build isolation is enforced by default. Source-only packages that need `setuptools` to compile then fail because the isolated build environment doesn't include it.
+
+**Affected packages:** `ovirt-engine-sdk-python` and `systemd-python` remain source-only. `ncclient` now ships a universal wheel and is no longer affected.
+
+**Prevention:** avoid `pip install --upgrade pip` in `prepend_base`. If an upgrade is needed, pin below 24: `pip install 'pip<24'`. Alternatively, add `ENV PIP_NO_BUILD_ISOLATION=1` in `prepend_base` to disable build isolation (pip will use system `setuptools` instead of creating an isolated env).
+
+**Builder version note:** `ansible-builder` 3.1+ adds the `dependencies.exclude` directive (useful when an EE's collections pull in packages already in the base image). The builder was previously pinned to 3.0.0 due to a misdiagnosed build isolation failure — the actual cause was `pip install --upgrade pip` in `network-ee`'s `prepend_base`, not the builder version.
 
 ## CI/CD Architecture
 

--- a/netbox-summit-2026-ee/ansible-collections.yml
+++ b/netbox-summit-2026-ee/ansible-collections.yml
@@ -12,35 +12,21 @@ collections:
 
   ## certified collections
   - name: ansible.controller
-    version: 4.7.10
   - name: ansible.eda
-    version: 2.11.0
   - name: ansible.hub
-    version: 1.0.6
   - name: ansible.platform
-    version: 2.6.20260306
   - name: ansible.netcommon
-    version: 8.5.0
   - name: ansible.network
-    version: 5.0.0
   - name: ansible.posix
-    version: 2.1.0
   - name: ansible.scm
-    version: 3.2.1
-  - name: ansible.security
-    version: 5.0.0
+#  - name: ansible.security
   - name: ansible.snmp
-    version: 3.1.0
   - name: ansible.utils
-    version: 6.0.2
   - name: ansible.yang
-    version: 3.1.0
 
   ## network vendor collections
   - name: arista.eos
     version: 12.0.1
-  - name: cisco.dnac
-    version: 6.49.0
   - name: cisco.ios
     version: 11.3.0
   - name: junipernetworks.junos

--- a/network-netbox-eda-ee/ansible-collections.yml
+++ b/network-netbox-eda-ee/ansible-collections.yml
@@ -3,7 +3,7 @@ collections:
 
 ## certified or galaxy netbox
   - name: netbox.netbox
-    version: 3.21.0
+    version: 3.22.0
 
 ## community collections
   - name: community.general
@@ -12,49 +12,29 @@ collections:
 ## validated collections
 
 
-## certified collections
+## ansible collections
   - name: ansible.netcommon               
-#    version: 7.1.0
   - name: ansible.network                 
-#    version: 4.0.0
   - name: ansible.posix                   
-#    version: 1.5.4
-  - name: ansible.scm                     
-#    version: 3.0.0
+#  - name: ansible.scm                     
 #  - name: ansible.security                
-#    version: 3.0.0
-  - name: ansible.snmp                    
-#    version: 3.0.0
+#  - name: ansible.snmp                    
   - name: ansible.utils                   
-#    version: 5.1.2
   - name: ansible.yang                    
-#    version: 3.0.0
-  - name: arista.eos                      
-#    version: 10.0.0
-  - name: cisco.ios
-#    version: 9.0.2
-  - name: junipernetworks.junos
-#    version: 9.1.0
 
-## disabled collections, due to conflict or unneeded
+## network vendors
+  - name: arista.eos                      
+  - name: cisco.ios
+  - name: junipernetworks.junos
+#  - name: cisco.nxos                      
+#  - name: cisco.dnac
+#  - name: cisco.meraki
+#  - name: servicenow.itsm                 
+#  - name: cisco.asa                       
+#  - name: cisco.iosxr                     
+
 ## alt netbox source for devel branch
 #  - name: https://github.com/netbox-community/ansible_modules.git
 #    version: devel
 #    type: git
-#  - name: ansible.controller              
-#    version: ">=4.6.1"
-#  - name: ansible.eda                     
-#    version: ">=2.1.0"
-#  - name: cisco.nxos                      
-#    version: 9.2.1
-#  - name: cisco.dnac
-#  - name: cisco.meraki
-#  - name: redhat.rhel_system_roles
-#    version: 1.21.1
-#  - name: servicenow.itsm                 
-#    version: 2.6.3
-#  - name: cisco.asa                       
-#    version: 6.0.0
-#  - name: cisco.iosxr                     
-#    version: 10.1.0
 


### PR DESCRIPTION
## Summary
- New workflow to apply version tags to EE images in quay.io
- Triggered by git tag push (pattern: `{ee-name}/v{version}`) or manual workflow_dispatch
- Uses skopeo to retag existing images — no rebuild needed
- Applies both an immutable tag (`v3.22-3`) and a floating base tag (`v3.22`)

## Usage
```bash
git tag netbox-summit-2026-ee/v3.22-3 <sha>
git push origin netbox-summit-2026-ee/v3.22-3
```

## Test plan
- [ ] Merge this PR
- [ ] Tag the #107 merge commit and push the tag
- [ ] Verify workflow runs in GitHub Actions
- [ ] Verify `v3.22-3` and `v3.22` tags appear in quay.io