### PR TITLE
Add registry.redhat.io login to preflight workflow

### DIFF
--- a/.github/workflows/pr-ee-preflight.yml
+++ b/.github/workflows/pr-ee-preflight.yml
@@ -63,6 +63,13 @@ jobs:
         with:
           python-version: "3.13"
 
+      - name: Log in to registry.redhat.io
+        uses: redhat-actions/podman-login@v1
+        with:
+          registry: registry.redhat.io
+          username: ${{ secrets.REDHAT_SA_USERNAME }}
+          password: ${{ secrets.REDHAT_SA_PASSWORD }}
+
       - name: Install ee-preflight
         run: pip install git+https://github.com/leogallego/ee-preflight.git@main
 


### PR DESCRIPTION
## Summary
- Add `podman-login` step for `registry.redhat.io` to the preflight workflow, using the same `REDHAT_SA_USERNAME`/`REDHAT_SA_PASSWORD` secrets already used by the build workflow
- Without this, Layer 3 (container wheel test) fails because it can't pull the base image from `registry.redhat.io`

## Test plan
- [ ] Re-run preflight on an existing PR that uses a `registry.redhat.io` base image and verify Layer 3 passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)