### PR TITLE
fix(aws_gameday_ee): use python3-devel to match system Python 3.9

### DIFF
--- a/aws_gameday_ee/bindep.txt
+++ b/aws_gameday_ee/bindep.txt
@@ -1,6 +1,6 @@
 unzip
 dnf
 systemd-devel [compile platform:rhel-9]
-python3.11-devel [compile platform:rhel-9]
+python3-devel [compile platform:rhel-9]
 pkgconf-pkg-config [compile platform:rhel-9]
 gcc [compile platform:rhel-9]

--- a/aws_gameday_ee/execution-environment.yml
+++ b/aws_gameday_ee/execution-environment.yml
@@ -23,7 +23,7 @@ additional_build_steps:
 #        - RUN /usr/bin/python3 -m ensurepip && /usr/bin/python3 -m pip install --upgrade pip setuptools
          - RUN microdnf install -y python3-pip && /usr/bin/python3 -m pip install --upgrade pip setuptools
     prepend_builder:
-        - RUN /usr/bin/microdnf install -y python3-pip python3.11-devel gcc && /usr/bin/python3 -m pip install --upgrade pip setuptools
+        - RUN /usr/bin/microdnf install -y python3-pip python3-devel gcc && /usr/bin/python3 -m pip install --upgrade pip setuptools
     prepend_galaxy:
         # Add custom ansible.cfg which defines collection install sources
         - ADD _build/configs/ansible.cfg /etc/ansible/ansible.cfg


### PR DESCRIPTION
## Summary
- The RHEL 9 base image (`ee-minimal-rhel9`) uses Python 3.9 as the system default
- `python3.11-devel` installs headers for Python 3.11, which the build does not use
- C extensions like `systemd_python` fail to compile with `fatal error: Python.h: No such file or directory`
- Switch to `python3-devel` in both `bindep.txt` and `prepend_builder` so headers match the running Python

## Test plan
- [ ] Rebuild the `aws_gameday_ee` execution environment and confirm `systemd_python` compiles successfully