### PR TITLE
fix(aws_gameday_ee): use python3.12-devel to match base image

### DIFF
--- a/aws_gameday_ee/bindep.txt
+++ b/aws_gameday_ee/bindep.txt
@@ -1,6 +1,6 @@
 unzip
 dnf
 systemd-devel [compile platform:rhel-9]
-python3-devel [compile platform:rhel-9]
+python3.12-devel [compile platform:rhel-9]
 pkgconf-pkg-config [compile platform:rhel-9]
 gcc [compile platform:rhel-9]

--- a/aws_gameday_ee/execution-environment.yml
+++ b/aws_gameday_ee/execution-environment.yml
@@ -23,7 +23,7 @@ additional_build_steps:
 #        - RUN /usr/bin/python3 -m ensurepip && /usr/bin/python3 -m pip install --upgrade pip setuptools
          - RUN microdnf install -y python3-pip && /usr/bin/python3 -m pip install --upgrade pip setuptools
     prepend_builder:
-        - RUN /usr/bin/microdnf install -y python3-pip python3-devel gcc && /usr/bin/python3 -m pip install --upgrade pip setuptools
+        - RUN /usr/bin/microdnf install -y python3-pip python3.12-devel gcc && /usr/bin/python3 -m pip install --upgrade pip setuptools
     prepend_galaxy:
         # Add custom ansible.cfg which defines collection install sources
         - ADD _build/configs/ansible.cfg /etc/ansible/ansible.cfg


### PR DESCRIPTION
## Summary
- Follow-up to #123 which landed with `python3-devel` instead of `python3.12-devel`
- The base image (`ee-minimal-rhel9:2.16`) runs Python 3.12, so `python3.12-devel` is needed for C extensions like `systemd_python` to compile

## Test plan
- [ ] Confirm the EE build completes successfully