### PR TITLE
fix(aws_gameday_ee): pin PYCMD to python3.12 to prevent python3.9 hijack

### DIFF
--- a/aws_gameday_ee/execution-environment.yml
+++ b/aws_gameday_ee/execution-environment.yml
@@ -23,7 +23,9 @@ additional_build_steps:
 #        - RUN /usr/bin/python3 -m ensurepip && /usr/bin/python3 -m pip install --upgrade pip setuptools
          - RUN microdnf install -y python3-pip && /usr/bin/python3 -m pip install --upgrade pip setuptools
     prepend_builder:
-        - RUN /usr/bin/microdnf install -y python3-pip python3.12-devel gcc && /usr/bin/python3 -m pip install --upgrade pip setuptools
+        - ENV PYCMD=/usr/bin/python3.12
+    prepend_final:
+        - ENV PYCMD=/usr/bin/python3.12
     prepend_galaxy:
         # Add custom ansible.cfg which defines collection install sources
         - ADD _build/configs/ansible.cfg /etc/ansible/ansible.cfg


### PR DESCRIPTION
## Summary
- microdnf pulls in python3-3.9 as a dependency, which hijacks `/usr/bin/python3` away from 3.12
- This causes `systemd_python` and other C extensions to compile against 3.9 headers that aren't installed
- Fix: pin `PYCMD=/usr/bin/python3.12` in builder and final stages, matching the pattern used by `netbox-for-nuno` and `netbox-summit-2026-ee`
- Also removes the manual microdnf install of python3-pip/gcc/devel from `prepend_builder` since `bindep.txt` already handles system deps

## Test plan
- [ ] Confirm the EE build completes successfully