### PR TITLE
fix(aws_gameday_ee): install builder script deps for python3.12

### DIFF
--- a/aws_gameday_ee/execution-environment.yml
+++ b/aws_gameday_ee/execution-environment.yml
@@ -24,6 +24,7 @@ additional_build_steps:
          - RUN microdnf install -y python3-pip && /usr/bin/python3 -m pip install --upgrade pip setuptools
     prepend_builder:
         - ENV PYCMD=/usr/bin/python3.12
+        - RUN $PYCMD -m pip install --upgrade pip setuptools requirements-parser bindep pyyaml distro packaging Parsley
     prepend_final:
         - ENV PYCMD=/usr/bin/python3.12
     prepend_galaxy:


### PR DESCRIPTION
## Summary
- Follow-up to #125 which pinned `PYCMD=/usr/bin/python3.12`
- The builder image has `requirements-parser`, `bindep`, etc. installed for Python 3.9 only
- With PYCMD pointing to 3.12, the introspect script fails with `No module named 'requirements'`
- Install the builder script dependencies under python3.12's pip

## Test plan
- [ ] Confirm the EE build passes the introspect step and completes successfully