### PR TITLE
fix: modernize CI workflows and simplify PR build

### DIFF
--- a/.github/workflows/pr-ee-build.yml
+++ b/.github/workflows/pr-ee-build.yml
@@ -20,18 +20,15 @@ jobs:
       length: ${{ steps.set-matrix.outputs.length }}
     steps:
     - name: Checkout repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         repository: ${{ github.event.pull_request.head.repo.full_name }}
         fetch-depth: 0
-        ref: ${{ github.event.pull_request.head.sha }} # exact commit
-        #ref: ${{ github.event.pull_request.head.ref != '' && github.event.pull_request.head.ref || 'main' }}
+        ref: ${{ github.event.pull_request.head.sha }}
 
     - name: Generate matrix
       id: generate-matrix
       run: |
-        echo $GITHUB_BASE_REF
-        echo $GITHUB_HEAD_REF
         python -u .github/workflows/generate_matrix.py \
         --start-ref origin/$GITHUB_BASE_REF \
         --end-ref $GITHUB_HEAD_REF \
@@ -41,65 +38,21 @@ jobs:
       id: set-matrix
       run: |
         MATRIX_JSON=$(cat matrix_output.json)
-        echo "::set-output name=matrix::$MATRIX_JSON"
-        MATRIX_LENGTH=$(echo $MATRIX_JSON | jq '.include | length')
-        echo $MATRIX_LENGTH
-        echo "::set-output name=length::$MATRIX_LENGTH"
-
-  debug:
-    needs: [prepare-matrix]
-    if: ${{ needs.prepare-matrix.outputs.length != '0' }}
-    runs-on: ubuntu-latest
-    environment: test
-    strategy:
-      matrix: ${{fromJson(needs.prepare-matrix.outputs.matrix)}}
-      fail-fast: false
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v2
-        with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.ref != '' && github.event.pull_request.head.ref || 'main' }}
-
-      - name: Print working directory
-        run: pwd
-
-      - name: List files in the directory
-        run: ls -lah
-
-      - name: List environment variables
-        run: printenv
-
-      - name: Show git branch and commit
-        run: |
-          echo "Current Branch:"
-          git branch
-          echo "Current Commit:"
-          git rev-parse HEAD
-
-      - name: Fetch all branches
-        run: git fetch --all
-
-      - name: List all remote branches
-        run: git branch -r
-
-      - name: Show detailed git diff
-        run: git diff origin/main
+        echo "matrix=$MATRIX_JSON" >> "$GITHUB_OUTPUT"
+        MATRIX_LENGTH=$(echo "$MATRIX_JSON" | jq '.include | length')
+        echo "length=$MATRIX_LENGTH" >> "$GITHUB_OUTPUT"
 
   build-ee:
     needs: [prepare-matrix]
     if: ${{ needs.prepare-matrix.outputs.length != '0' }}
-    # outputs:
-    #   push_success: ${{ steps.push_to_ghcr.outputs.push_success }}
     runs-on: ubuntu-latest
     environment: test
     strategy:
-      matrix: ${{fromJson(needs.prepare-matrix.outputs.matrix)}}
+      matrix: ${{ fromJson(needs.prepare-matrix.outputs.matrix) }}
       fail-fast: false
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           fetch-depth: 0
@@ -114,14 +67,6 @@ jobs:
           SHORT_SHA=$(echo ${{ github.sha }} | cut -c1-7)
           echo "IMAGE_TAG=pr-${{ github.event.number }}-$SHORT_SHA" >> $GITHUB_ENV
 
-      # Login to ghcr not needed for PR builds since we don't push
-      # - name: Login to ghcr
-      #   uses: redhat-actions/podman-login@v1
-      #   with:
-      #     registry: ghcr.io
-      #     username: ${{ github.actor }}
-      #     password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Log in to registry.redhat.io
         uses: redhat-actions/podman-login@v1
         with:
@@ -133,100 +78,25 @@ jobs:
         run: |
           sed -i "s/my_ah_token/${{ secrets.AH_TOKEN }}/g" ansible.cfg
 
-      - name: Build image and create artifact
+      - name: Build image
         working-directory: ${{ matrix.ee }}
         run: |
           ansible-builder build -v 3 \
           --build-arg AH_TOKEN=${{ secrets.AH_TOKEN }} \
           --context=../${{ env.EE }} \
-          --tag=${{ env.EE }}:${{ env.IMAGE_TAG }} \
-          --tag=${{ env.EE }}:${{ github.sha }}
-
-          # Create artifact file
-          COMMANDS_FILE="commands-${{ matrix.ee }}.txt"
-          echo "" >> $COMMANDS_FILE
-          echo "${{ env.EE }}" >> $COMMANDS_FILE
-          echo "" >> $COMMANDS_FILE
-          echo "**Build Status:** ✅ Success" >> $COMMANDS_FILE
-          echo "" >> $COMMANDS_FILE
-          echo "_Image built locally but not pushed to registry for PR builds_" >> $COMMANDS_FILE
-          echo "" >> $COMMANDS_FILE
-          echo "<details>" >> $COMMANDS_FILE
-          echo "<summary><b>More info...</b></summary>" >> $COMMANDS_FILE
-          echo "" >> $COMMANDS_FILE
-          echo "#### Installed collections" >> $COMMANDS_FILE
-          echo "" >> $COMMANDS_FILE
-          echo "\`\`\`" >> $COMMANDS_FILE
-          podman run -it ${{ env.EE }}:${{ env.IMAGE_TAG }} ansible-galaxy collection list  >> $COMMANDS_FILE
-          echo "\`\`\`" >> $COMMANDS_FILE
-          echo "" >> $COMMANDS_FILE
-          echo "#### Ansible version" >> $COMMANDS_FILE
-          echo "" >> $COMMANDS_FILE
-          echo "\`\`\`" >> $COMMANDS_FILE
-          podman run -it ${{ env.EE }}:${{ env.IMAGE_TAG }} ansible --version  >> $COMMANDS_FILE
-          echo "\`\`\`" >> $COMMANDS_FILE
-          echo "</details>" >> $COMMANDS_FILE
-
-      - name: Upload build artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: commands-${{ matrix.ee }}
-          path: ${{ matrix.ee }}/commands-${{ matrix.ee }}.txt
-
-      # Disabled for PR builds - images are only pushed when merged to main
-      # - name: Push To GHCR
-      #   id: push_to_ghcr
-      #   uses: redhat-actions/push-to-registry@v2
-      #   with:
-      #     image: ${{ env.EE }}
-      #     tags: ${{ env.IMAGE_TAG }}
-      #     registry: ${{ env.IMAGE_REGISTRY }}/${{ github.repository_owner }}
-
-      # - name: Set push success flag
-      #   if: success()
-      #   run: echo "push_success=true" >> $GITHUB_ENV
+          --tag=${{ env.EE }}:${{ env.IMAGE_TAG }}
 
       - name: Print summary
         run: |
-          echo "## :rocket: Build Complete" >> $GITHUB_STEP_SUMMARY
+          echo "## Build Complete" >> $GITHUB_STEP_SUMMARY
           echo "Image built successfully: ${{ env.EE }}:${{ env.IMAGE_TAG }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "_Note: Images are not pushed to ghcr.io for PR builds. They will be pushed when merged to main._" >> $GITHUB_STEP_SUMMARY
-
-  post-comment:
-    needs: build-ee
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Download Artifacts
-        uses: actions/download-artifact@v4
-
-      - name: Post Comment
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('fs');
-            const path = require('path');
-            let commentBody = '### :rocket: **EE Images Built** :rocket:\n\n';
-
-            const artifactsDirectory = './';  // Base directory where artifacts are downloaded
-            fs.readdirSync(artifactsDirectory, { withFileTypes: true }).forEach(dirent => {
-              if (dirent.isDirectory() && dirent.name.startsWith('commands-')) {
-                const artifactDirPath = path.join(artifactsDirectory, dirent.name);
-                fs.readdirSync(artifactDirPath).forEach(file => {
-                  const filePath = path.join(artifactDirPath, file);
-                  const content = fs.readFileSync(filePath, 'utf8');
-                  commentBody += content + '\n';
-                });
-              }
-            });
-
-            const prNumber = context.issue.number;
-            const repo = context.repo;
-            github.rest.issues.createComment({
-              ...repo,
-              issue_number: prNumber,
-              body: commentBody.trim()
-            });
+          echo "### Installed collections" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          podman run --rm ${{ env.EE }}:${{ env.IMAGE_TAG }} ansible-galaxy collection list >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Ansible version" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          podman run --rm ${{ env.EE }}:${{ env.IMAGE_TAG }} ansible --version >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/push-ee-build.yml
+++ b/.github/workflows/push-ee-build.yml
@@ -13,11 +13,11 @@ jobs:
       length: ${{ steps.set-matrix.outputs.length }}
     steps:
     - name: Checkout repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
-    - name: Generate matrix  
+    - name: Generate matrix
       id: generate-matrix
       working-directory: ${{ github.workspace }}
       run: |
@@ -31,10 +31,9 @@ jobs:
       working-directory: ${{ github.workspace }}
       run: |
         MATRIX_JSON=$(cat matrix_output.json)
-        echo "::set-output name=matrix::$MATRIX_JSON"
-        MATRIX_LENGTH=$(echo $MATRIX_JSON | jq '.include | length')
-        echo $MATRIX_LENGTH
-        echo "::set-output name=length::$MATRIX_LENGTH"
+        echo "matrix=$MATRIX_JSON" >> "$GITHUB_OUTPUT"
+        MATRIX_LENGTH=$(echo "$MATRIX_JSON" | jq '.include | length')
+        echo "length=$MATRIX_LENGTH" >> "$GITHUB_OUTPUT"
 
   build-ee:
     needs: [prepare-matrix]
@@ -46,15 +45,9 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.head_ref }}
-
-      - name: Fetch the base and head refs
-        run: |
-          git fetch origin ${{ github.base_ref }}
-          git fetch origin ${{ github.head_ref }}
 
       - name: Install python requirements (ansible-builder)
         run: pip install -r requirements.txt
@@ -81,10 +74,6 @@ jobs:
       - name: Substitute token for automation hub
         run: |
           sed -i "s/my_ah_token/${{ secrets.AH_TOKEN }}/g" ansible.cfg
-
-      - name: (devel) Build image and create artifact
-        run: |
-          echo "Would build: ${{ env.EE }}"
 
       - name: Build image and create artifact
         working-directory: ${{ matrix.ee }}


### PR DESCRIPTION
## Summary
- Upgrade actions/checkout@v2 to @v4 (fixes Node.js 20 deprecation)
- Replace deprecated ::set-output with GITHUB_OUTPUT in both workflows
- Remove debug job from PR workflow
- Remove post-comment job and artifact upload from PR workflow; build info goes to step summary
- Remove commented-out ghcr push code from PR workflow
- Remove dummy "(devel) Build image" echo step from prod workflow
- Remove unnecessary head_ref/base_ref fetch from prod workflow
- PR builds only verify the image builds, no push to any registry

## Test plan
- [ ] Merge this, then open a test PR touching an EE to confirm the updated devel workflow runs