### PR TITLE
Unpin ansible-builder from 3.0.0

### DIFF
--- a/network-ee/bindep.txt
+++ b/network-ee/bindep.txt
@@ -10,7 +10,7 @@ libxml2-devel [platform:rpm]
 libxslt-devel [platform:rpm]
 
 # RHEL/UBI
-python3-devel [platform:rpm]
+python3.12-devel [platform:rpm]
 krb5-devel     [platform:rpm]
 gcc            [platform:rpm]
 redhat-rpm-config [platform:rpm]

--- a/network-ee/requirements.txt
+++ b/network-ee/requirements.txt
@@ -1,4 +1,5 @@
 # Extra Python packages not already satisfied by ee-supported-rhel9 base image.
+# ovirt-engine-sdk-python is source-only — requires setuptools to compile.
 # Most network collection deps (ncclient, paramiko, textfsm, ttp, jxmlease,
 # xmltodict, netaddr, scp, etc.) are pre-installed via the base image's
 # bundled collections. Only add packages the DELTA collections need or

--- a/network-netbox-eda-ee/ansible-collections.yml
+++ b/network-netbox-eda-ee/ansible-collections.yml
@@ -16,7 +16,7 @@ collections:
   - name: ansible.netcommon               
   - name: ansible.network                 
   - name: ansible.posix                   
-#  - name: ansible.scm                     
+  - name: ansible.scm
 #  - name: ansible.security                
 #  - name: ansible.snmp                    
   - name: ansible.utils                   

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-ansible-builder==3.0.0
+ansible-builder


### PR DESCRIPTION
## Summary
Rebased version of #97 (by @leogallego) with conflicts resolved.

- Unpin `ansible-builder` from `3.0.0` in `requirements.txt`, giving access to 3.1+ features like `dependencies.exclude`
- Re-enable `ansible.scm` in `network-netbox-eda-ee`
- Add comment to `network-ee/requirements.txt` about source-only packages

The build isolation issue was caused by `pip install --upgrade pip` in EE definitions, not by the builder version. See CLAUDE.md "pip Build Isolation" section.

## Credit
Original work by @leogallego in #97.

## Test plan
- [ ] Confirm `network-ee` (has source-only `ovirt-engine-sdk-python`) builds successfully
- [ ] Confirm `network-netbox-eda-ee` builds with `ansible.scm` re-enabled