### PR TITLE
feat: add build rules, test EEs, and CI workflow

### DIFF
--- a/.claude/rules/01-python-version-pitfalls.md
+++ b/.claude/rules/01-python-version-pitfalls.md
@@ -1,0 +1,94 @@
+---
+description: Python version pitfalls in RHEL 9 EE builds — PYCMD hijack, python-devel matching, builder dependency reinstall
+globs: "**/execution-environment.yml,**/bindep.txt"
+alwaysApply: false
+---
+
+# Python Version Pitfalls
+
+## A. PYCMD Hijack on RHEL 9
+
+On RHEL 9 ee-minimal images, the base image ships Python 3.12 at `/usr/bin/python3.12` with `/usr/bin/python3` symlinked to it. When `microdnf` installs system packages (from bindep.txt or build steps), it pulls in `python3-3.9` as a transitive dependency. The `python3-3.9` RPM takes ownership of `/usr/bin/python3`, so `$PYCMD` resolves to Python 3.9 instead of 3.12.
+
+This causes: wrong wheels downloaded (cp39 instead of cp312), C extensions compiled against wrong headers, and packages installed into the wrong site-packages.
+
+**Affected**: AAP 2.6 ee-minimal-rhel9, AAP 2.7 ee-minimal-rhel9 (any RHEL 9 ee-minimal).
+**Not affected**: RHEL 8 images, ee-supported images.
+
+### DO
+
+```yaml
+# Pin PYCMD in BOTH builder and final stages
+prepend_builder:
+    - ENV PYCMD=/usr/bin/python3.12
+prepend_final:
+    - ENV PYCMD=/usr/bin/python3.12
+```
+
+Reference: `netbox-for-nuno`, `netbox-summit-2026-ee`, `aws_gameday_ee`.
+
+### DON'T
+
+```yaml
+# No PYCMD override — microdnf will hijack /usr/bin/python3 to 3.9
+prepend_builder: []
+```
+
+```yaml
+# Setting PYCMD only in builder — final image still has wrong Python
+prepend_builder:
+    - ENV PYCMD=/usr/bin/python3.12
+# Missing prepend_final!
+```
+
+## B. python-devel Must Match the Active Python
+
+The `python3.XX-devel` package in bindep.txt provides C header files (`Python.h`) for compilation. It MUST match the Python version the builder compiles C extensions with (i.e., what `$PYCMD` resolves to after applying the PYCMD fix).
+
+| Base Image | Python | Correct devel package |
+|-----------|--------|----------------------|
+| AAP 2.6/2.7 ee-minimal-rhel9 | 3.12 | `python3.12-devel` |
+| AAP 2.5 ee-minimal-rhel8 | 3.11 | `python3.11-devel` |
+| AAP 2.4 ee-minimal-rhel8 | 3.12 | `python3.12-devel` |
+
+### DO
+
+```
+python3.12-devel [compile platform:rhel-9]
+```
+
+### DON'T
+
+```
+# WRONG: Headers for 3.11 but builder compiles with 3.12
+python3.11-devel [compile platform:rhel-9]
+
+# WRONG: Generic python3-devel may resolve to 3.9 headers after hijack
+python3-devel [compile platform:rhel-9]
+```
+
+## C. Builder Script Dependencies Reinstall (AAP 2.7 Only)
+
+When you override `PYCMD=/usr/bin/python3.12` in `prepend_builder`, the builder's introspection scripts (`introspect.py`) run under Python 3.12. But the builder image installed their dependencies (`requirements-parser`, `bindep`, `pyyaml`, etc.) for the default Python 3.9. The introspect step fails with `ModuleNotFoundError: No module named 'requirements'`.
+
+This is needed for AAP 2.7. AAP 2.6 builder images handle this differently and do NOT need the reinstall.
+
+### DO (AAP 2.7)
+
+```yaml
+prepend_builder:
+    - ENV PYCMD=/usr/bin/python3.12
+    - RUN $PYCMD -m pip install --upgrade pip setuptools requirements-parser bindep pyyaml distro packaging Parsley
+prepend_final:
+    - ENV PYCMD=/usr/bin/python3.12
+```
+
+Reference: `aws_gameday_ee`.
+
+### DON'T (AAP 2.7)
+
+```yaml
+# Sets PYCMD but doesn't reinstall builder deps — introspect scripts fail
+prepend_builder:
+    - ENV PYCMD=/usr/bin/python3.12
+```

--- a/.claude/rules/02-pip-build-isolation.md
+++ b/.claude/rules/02-pip-build-isolation.md
@@ -1,0 +1,60 @@
+---
+description: pip build isolation traps — pip upgrade breaks source-only packages, PIP_NO_BUILD_ISOLATION, pip pinning
+globs: "**/execution-environment.yml,**/requirements.txt,**/python-packages.txt"
+alwaysApply: false
+---
+
+# pip Build Isolation
+
+## The pip Upgrade Trap
+
+`ansible-builder` calls `ensurepip` which keeps the base image's pip (23.x). Build isolation is lax at pip <24.
+
+When an EE's `prepend_base` runs `RUN $PYCMD -m pip install --upgrade pip`, pip upgrades to 24+ which enforces PEP 517 build isolation by default. Source-only packages then fail because the isolated build environment lacks `setuptools`.
+
+## Affected Packages
+
+These Python packages have no pre-built wheel on PyPI and require compilation from source:
+
+- `systemd-python`: needs `setuptools`, `systemd-devel`, `gcc`
+- `ovirt-engine-sdk-python`: needs `setuptools`, `libxml2-devel`, `libxslt-devel`, `gcc`
+- `ncclient`: previously source-only, now ships a universal wheel (no longer affected)
+
+## Fixes (Choose One)
+
+### Option 1: Pin pip below 24 (recommended when you need pip features)
+
+```yaml
+prepend_base:
+    - RUN $PYCMD -m pip install 'pip<24' setuptools
+```
+
+### Option 2: Disable build isolation
+
+```yaml
+prepend_base:
+    - ENV PIP_NO_BUILD_ISOLATION=1
+    - RUN $PYCMD -m pip install --upgrade pip setuptools
+```
+
+pip will use the system `setuptools` instead of creating an isolated environment.
+
+### Option 3: Do not upgrade pip (safest)
+
+```yaml
+prepend_base: []
+```
+
+Rely on the base image's pip. This is the simplest approach and avoids the problem entirely.
+
+Reference: `network-ee` uses `ensurepip` only (no upgrade) specifically because it installs `ovirt-engine-sdk-python`.
+
+## DON'T
+
+```yaml
+# Upgrades to pip 24+ — source-only packages will fail
+prepend_base:
+    - RUN $PYCMD -m pip install --upgrade pip setuptools
+```
+
+This pattern exists in many EEs in the repo. It works only because those EEs do not install source-only packages. Adding `systemd-python` or `ovirt-engine-sdk-python` to their requirements.txt will break the build.

--- a/.claude/rules/03-multi-stage-build-mechanics.md
+++ b/.claude/rules/03-multi-stage-build-mechanics.md
@@ -1,0 +1,73 @@
+---
+description: ansible-builder v3 multi-stage build — what persists, ENV placement, file placement across 4 stages
+globs: "**/execution-environment.yml"
+alwaysApply: false
+---
+
+# Multi-Stage Build Mechanics
+
+## Stage Persistence
+
+`ansible-builder` v3 generates a 4-stage Containerfile:
+
+| Stage | Build Steps Key | What Survives | What Is Discarded |
+|-------|----------------|---------------|-------------------|
+| 1. base | `prepend_base` / `append_base` | Everything (foundation of final image) | Nothing |
+| 2. galaxy | `prepend_galaxy` / `append_galaxy` | Only `/usr/share/ansible` (collections) | All other files, ENV vars, installed packages |
+| 3. builder | `prepend_builder` / `append_builder` | Only `/output/` (compiled wheels) | All other files, ENV vars, system packages |
+| 4. final | `prepend_final` / `append_final` | Everything (this IS the shipped image) | Nothing |
+
+## Common Mistakes
+
+### ansible.cfg in galaxy stage does NOT persist
+
+```yaml
+# WRONG: ansible.cfg is lost after galaxy stage completes
+prepend_galaxy:
+    - ADD _build/configs/ansible.cfg /etc/ansible/ansible.cfg
+# The final image gets the BASE IMAGE's original ansible.cfg
+```
+
+The galaxy stage ansible.cfg is correct for collection installation (it needs the AH token). But if you also need ansible.cfg at runtime, add it separately in the final stage:
+
+```yaml
+append_final:
+    - ADD _build/configs/ansible.cfg /etc/ansible/ansible.cfg
+```
+
+Reference: `network-ee` does this correctly.
+
+### ENV placement matters
+
+- `ENV` in `prepend_base`: persists to the final image (good for runtime config)
+- `ENV` in `prepend_galaxy`: discarded after collection install
+- `ENV` in `prepend_builder`: discarded after wheel compilation
+- `ENV` in `prepend_final`: persists to the final image
+
+```yaml
+# CORRECT: Runtime ENV in prepend_base persists everywhere
+prepend_base:
+    - ENV ANSIBLE_COLLECTIONS_ON_ANSIBLE_VERSION_MISMATCH=ignore
+
+# CORRECT: AH_TOKEN only needed during galaxy stage
+prepend_galaxy:
+    - ARG AH_TOKEN
+    - ENV ANSIBLE_GALAXY_SERVER_AUTOMATION_HUB_TOKEN=$AH_TOKEN
+```
+
+### PYCMD must be set in BOTH builder and final
+
+Setting `ENV PYCMD` only in `prepend_builder` fixes the build compilation, but the final image still has the wrong PYCMD. Both stages need it:
+
+```yaml
+prepend_builder:
+    - ENV PYCMD=/usr/bin/python3.12
+prepend_final:
+    - ENV PYCMD=/usr/bin/python3.12
+```
+
+### ARG vs ENV
+
+- Use `ARG` for build-time secrets (like `AH_TOKEN`) that should NOT persist in the image
+- Use `ENV` for configuration that needs to persist at runtime
+- `ARG` values are available only in the stage where they are declared

--- a/.claude/rules/04-base-image-selection.md
+++ b/.claude/rules/04-base-image-selection.md
@@ -1,0 +1,86 @@
+---
+description: Base image selection guide — AAP/RHEL/Python version matrix, ee-minimal vs ee-supported, delta dependencies
+globs: "**/execution-environment.yml,**/requirements.yml,**/ansible-collections.yml"
+alwaysApply: false
+---
+
+# Base Image Selection
+
+## Image Naming Convention
+
+```
+registry.redhat.io/ansible-automation-platform-{AAP_VERSION}/{IMAGE_TYPE}-{RHEL_VERSION}:{TAG}
+```
+
+- AAP versions: 24, 25, 26, 27
+- Image types: `ee-minimal`, `ee-supported`, `de-minimal` (EDA Decision Environments), `de-supported` (EDA Decision Environments)
+- RHEL versions: `rhel8`, `rhel9`
+- Tags: `:latest` or pinned (e.g., `:2.16-1781093888`)
+
+## Python Version by Base Image
+
+| AAP | RHEL | ee-minimal Python | ee-supported Python |
+|-----|------|-------------------|---------------------|
+| 24 | rhel8 | 3.12 | 3.9 |
+| 24 | rhel9 | 3.12 | 3.12 |
+| 25 | rhel8 | 3.12 | 3.11 |
+| 25 | rhel9 | 3.12 | 3.12 |
+| 26 | rhel9 | 3.12 | 3.12 |
+| 27 | rhel9 | 3.12 | 3.12 |
+
+This table determines which `python3.XX-devel` package to use in bindep.txt (see rule 01).
+
+## ee-minimal vs ee-supported
+
+**Use ee-minimal when:**
+- You want full control over which collections are installed
+- You want the smallest possible image size
+- You are building a purpose-specific EE (e.g., AWS-only, ServiceNow-only)
+
+**Use ee-supported when:**
+- You need pre-bundled Red Hat certified collections (network, cloud, etc.)
+- You only need to add a few extra collections on top
+- You want the collections Red Hat supports and tests together
+
+## Delta-Only Dependencies for ee-supported
+
+ee-supported ships many collections and Python packages pre-installed. Only add what is NOT already in the base image. Overriding bundled deps causes version conflicts and runtime warnings.
+
+### DO
+
+```yaml
+collections:
+  - name: cisco.asa           # NOT in ee-supported base
+  - name: servicenow.itsm     # NOT in ee-supported base
+```
+
+### DON'T
+
+```yaml
+collections:
+  - name: cisco.ios            # Already in ee-supported!
+  - name: ansible.netcommon    # Already in ee-supported!
+  - name: ansible.utils        # Already in ee-supported!
+```
+
+To check what's in a base image:
+
+```bash
+podman run --rm <base-image> ansible-galaxy collection list
+podman run --rm <base-image> pip list
+```
+
+## RHEL 9 Considerations
+
+When using any RHEL 9 ee-minimal image:
+
+1. The PYCMD hijack applies (see rule 01). Always set `ENV PYCMD=/usr/bin/python3.12` in prepend_builder and prepend_final.
+2. Default crypto policies may break SSH to older devices (see rule 05).
+3. Use `python3.12-devel` (not `python3-devel` or `python3.11-devel`) in bindep.txt.
+
+## Tag Pinning
+
+- Use `:latest` for most EEs (gets security updates automatically)
+- Pin to a specific tag (e.g., `:2.16-1781093888`) only when build reproducibility is critical
+- Example of pinned: `aws_gameday_ee`
+- Example of latest: `netbox-summit-2026-ee`

--- a/.claude/rules/05-common-workarounds.md
+++ b/.claude/rules/05-common-workarounds.md
@@ -1,0 +1,126 @@
+---
+description: Common workarounds — legacy crypto on RHEL 9, PIP_IGNORE_INSTALLED, collection version mismatch suppression
+globs: "**/execution-environment.yml,**/bindep.txt"
+alwaysApply: false
+---
+
+# Common Workarounds
+
+## Legacy Crypto on RHEL 9
+
+RHEL 9 default crypto policies disable SHA-1, DSA, and weak DH groups. SSH to older network devices (IOS-XE, NX-OS, JunOS, older Linux hosts) fails with errors like `kex_exchange_identification` or `no matching host key type found`.
+
+### Approach 1: update-crypto-policies (system-wide)
+
+```yaml
+append_final:
+    - RUN microdnf install -y crypto-policies-scripts && update-crypto-policies --set DEFAULT:SHA1 && microdnf clean all
+```
+
+Pro: Official Red Hat method, one line.
+Con: Weakens all crypto system-wide in the container.
+
+Reference: `network-ee`.
+
+### Approach 2: Surgical config replacement (targeted)
+
+```yaml
+additional_build_files:
+    - src: crypto-policies/libssh-legacy.config
+      dest: configs
+    - src: crypto-policies/opensslcnf-legacy.config
+      dest: configs
+
+additional_build_steps:
+    prepend_final:
+        - ADD _build/configs/libssh-legacy.config /etc/crypto-policies/back-ends/libssh.config
+        - ADD _build/configs/opensslcnf-legacy.config /etc/crypto-policies/back-ends/opensslcnf.config
+```
+
+Pro: Only affects SSH/TLS backends, leaves rest of crypto policy intact.
+Con: Requires maintaining the config files in the EE directory.
+
+Reference: `netbox-summit-2026-ee-legacy-crypto`, `netbox-webinar-legacy-crypto-ee`.
+
+### SSH-specific ENV
+
+For libssh RSA key support without changing crypto policies:
+
+```yaml
+prepend_base:
+    - ENV ANSIBLE_LIBSSH_PUBLICKEY_ALGORITHMS=ssh-rsa
+```
+
+Reference: `network-ee`.
+
+## Collection System Dependencies Not Available in UBI
+
+Some collections declare system packages in their `bindep.txt` that are not available in standard UBI repositories. The most common example is `kubernetes.core` which requires `openshift-clients`, an RPM only available with an OpenShift subscription.
+
+### Fix: Exclude the system dependency (ansible-builder 3.1+)
+
+```yaml
+dependencies:
+  galaxy: requirements.yml
+  python: requirements.txt
+  system: bindep.txt
+  exclude:
+    system:
+      - openshift-clients
+```
+
+This tells ansible-builder to skip `openshift-clients` from the collection's introspected bindep. The core `k8s`, `k8s_info`, `helm` modules work fine without it (they use the Python `kubernetes` client). Only the `kubectl` connection plugin and `kustomize` lookup actually need the binary.
+
+If you do need the binary, you have two options:
+
+Option A: Enable the OpenShift repo via PKGMGR_OPTS (for hosts with subscription-manager):
+```yaml
+prepend_builder:
+    - ENV PKGMGR_OPTS="--nodocs --setopt=install_weak_deps=0 --setopt=rhocp-4.16-for-rhel-9-x86_64-rpms.enabled=true"
+prepend_final:
+    - ENV PKGMGR_OPTS="--nodocs --setopt=install_weak_deps=0 --setopt=rhocp-4.16-for-rhel-9-x86_64-rpms.enabled=true"
+```
+Must be set in both builder and final stages. Adjust the repo name for your RHEL and OCP versions.
+
+Option B: Bundle the RPM directly (for RHUI/cloud environments without the OCP repo):
+```yaml
+additional_build_files:
+    - src: openshift-clients-4.16.x.rpm
+      dest: rpms
+additional_build_steps:
+    prepend_base:
+        - COPY _build/rpms/*.rpm /tmp/openshift-clients.rpm
+        - RUN rpm -ivh /tmp/openshift-clients.rpm
+```
+
+Reference: [Red Hat Solution 7024259](https://access.redhat.com/solutions/7024259), `product-demos-ee`.
+
+Reference: [kubernetes.core#1141](https://github.com/ansible-collections/kubernetes.core/issues/1141)
+
+## PIP_IGNORE_INSTALLED
+
+When pip encounters a package already installed by the base image's RPM, it may refuse to upgrade or get confused by dist-info ownership conflicts.
+
+```yaml
+prepend_base:
+    - ENV PIP_IGNORE_INSTALLED=1
+```
+
+This tells pip to ignore already-installed packages and install fresh copies. Use only when RPM-installed packages conflict with pip version requirements.
+
+Tradeoff: increases image size due to duplicate packages.
+
+Reference: `netbox-for-nuno`, `netbox-summit-2026-ee`, `network-netbox-eda-ee`.
+
+## Collection Version Mismatch Suppression
+
+ee-supported images bundle collections that may declare `requires_ansible: ">=2.17"` but ship ansible-core 2.15 or 2.16. This produces noisy runtime warnings.
+
+```yaml
+prepend_base:
+    - ENV ANSIBLE_COLLECTIONS_ON_ANSIBLE_VERSION_MISMATCH=ignore
+```
+
+Put this in `prepend_base` (not in ansible.cfg in the galaxy stage, which would be discarded).
+
+Reference: `network-ee`.

--- a/.claude/rules/06-debugging-builds.md
+++ b/.claude/rules/06-debugging-builds.md
@@ -1,0 +1,38 @@
+---
+description: Comprehensive symptom-cause-fix table for debugging EE build failures
+globs: "**/execution-environment.yml,**/bindep.txt,**/requirements.txt,**/python-packages.txt"
+alwaysApply: false
+---
+
+# Debugging EE Builds
+
+## Symptom / Cause / Fix Reference
+
+| Symptom | Cause | Fix | Rule |
+|---------|-------|-----|------|
+| `fatal error: Python.h: No such file or directory` | Missing python-devel or wrong version in bindep.txt | Add `python3.12-devel` (must match active Python) to bindep.txt | 01-B |
+| `ModuleNotFoundError: No module named 'requirements'` in builder introspect step | PYCMD overridden to 3.12 but builder scripts only installed for 3.9 (AAP 2.7) | Add `RUN $PYCMD -m pip install ... requirements-parser bindep pyyaml distro packaging Parsley` in prepend_builder | 01-C |
+| `ModuleNotFoundError: No module named 'setuptools'` during pip install | pip 24+ enforces PEP 517 build isolation; source-only package needs setuptools | Pin `pip<24`, set `ENV PIP_NO_BUILD_ISOLATION=1`, or don't upgrade pip | 02 |
+| `No module named 'ansible'` in check_ansible step | Final image `/usr/bin/python3` points to 3.9 but ansible installed under 3.12 | Set `ENV PYCMD=/usr/bin/python3.12` in prepend_final | 01-A |
+| Wheels downloaded as `cp39` instead of `cp312` | PYCMD hijacked to Python 3.9 by microdnf | Set `ENV PYCMD=/usr/bin/python3.12` in prepend_builder and prepend_final | 01-A |
+| `error: command 'gcc' failed` | gcc not installed in builder | Add `gcc [compile platform:rhel-9]` to bindep.txt | 01-B |
+| `No package matches 'python39-devel'` | Wrong python-devel package name for the RHEL version | Use `python3.12-devel` for RHEL 9, `python3.11-devel` for RHEL 8 AAP 2.5 | 01-B |
+| Galaxy stage fails with 401/403 | AH_TOKEN missing or expired | Check `--build-arg AH_TOKEN=...`, verify token is fresh, check ansible.cfg server config | CI |
+| Galaxy stage fails with 504 | Automation Hub transient error | Rerun the workflow | CI |
+| Galaxy warnings: `Skipping Galaxy server ... HTTP Error 400` | Validated content server auth issue | Non-fatal if collections install from fallback servers. To fix, add token to validated server config in ansible.cfg | CI |
+| Collection version warnings at runtime | ee-supported base collections declare higher ansible-core than shipped | `ENV ANSIBLE_COLLECTIONS_ON_ANSIBLE_VERSION_MISMATCH=ignore` in prepend_base | 05 |
+| SSH to device fails with `kex_exchange_identification` | RHEL 9 crypto policies reject legacy algorithms | Use `update-crypto-policies --set DEFAULT:SHA1` or surgical config replacement in append_final | 05 |
+| `ansible.cfg` changes missing at runtime | ansible.cfg added only in galaxy stage (discarded after collection install) | Also ADD ansible.cfg in `append_final` if runtime config is needed | 03 |
+| `No module named pip` in base stage | Base image does not ship pip | Install via `microdnf install -y python3-pip` or `RUN $PYCMD -m ensurepip` in prepend_base | 01 |
+| pip installing into wrong Python / wrong site-packages | `/usr/bin/python3` hijacked to 3.9 | Always use `$PYCMD -m pip install` with PYCMD override, never bare `pip install` | 01-A |
+
+| `No package matches 'openshift-clients'` | `kubernetes.core` collection declares `openshift-clients` in its bindep.txt, which is not available in standard UBI repos | Use `dependencies.exclude.system: [openshift-clients]` in execution-environment.yml (requires ansible-builder 3.1+), or add `openshift-clients` RPM manually via `additional_build_steps` if actually needed | 05 |
+
+## Quick Diagnostic Steps
+
+1. **Check which Python the image uses**: `podman run --rm <image> python3 --version`
+2. **Check where python3 points**: `podman run --rm <image> ls -la /usr/bin/python3*`
+3. **Check installed collections**: `podman run --rm <image> ansible-galaxy collection list`
+4. **Check ansible version**: `podman run --rm <image> ansible --version`
+5. **Check pip packages**: `podman run --rm <image> python3 -m pip list`
+6. **Build with maximum verbosity**: `ansible-builder build -v 3 ...`

--- a/.claude/rules/07-adding-new-ees.md
+++ b/.claude/rules/07-adding-new-ees.md
@@ -1,0 +1,87 @@
+---
+description: Checklist for adding a new EE definition — covers all known pitfalls in sequence
+globs: "**/execution-environment.yml"
+alwaysApply: false
+---
+
+# Adding a New EE
+
+## Checklist
+
+1. **Choose base image** (see rule 04)
+   - ee-minimal or ee-supported?
+   - AAP version (24, 25, 26, 27)?
+   - RHEL version (rhel8, rhel9)?
+
+2. **Check Python version** of chosen base image
+   ```bash
+   podman run --rm <base-image> python3 --version
+   ```
+
+3. **If RHEL 9 ee-minimal**: add PYCMD override (see rule 01-A)
+   ```yaml
+   prepend_builder:
+       - ENV PYCMD=/usr/bin/python3.12
+   prepend_final:
+       - ENV PYCMD=/usr/bin/python3.12
+   ```
+
+4. **If AAP 2.7**: also reinstall builder script dependencies (see rule 01-C)
+   ```yaml
+   prepend_builder:
+       - ENV PYCMD=/usr/bin/python3.12
+       - RUN $PYCMD -m pip install --upgrade pip setuptools requirements-parser bindep pyyaml distro packaging Parsley
+   ```
+
+5. **Set correct python-devel in bindep.txt** (see rule 01-B)
+   - Must match the Python your PYCMD resolves to
+   - AAP 2.6/2.7 rhel9: `python3.12-devel [compile platform:rhel-9]`
+   - AAP 2.5 rhel8: `python3.11-devel [compile platform:rhel-8]`
+
+6. **If using source-only packages** (systemd-python, ovirt-engine-sdk-python): do NOT upgrade pip, or use PIP_NO_BUILD_ISOLATION (see rule 02)
+
+7. **If using ee-supported base**: only add delta collections and packages not already in the base image (see rule 04)
+
+8. **Add ansible.cfg** to `additional_build_files` and inject in `prepend_galaxy`
+   ```yaml
+   additional_build_files:
+       - src: ansible.cfg
+         dest: configs
+   additional_build_steps:
+       prepend_galaxy:
+           - ADD _build/configs/ansible.cfg /etc/ansible/ansible.cfg
+           - ARG AH_TOKEN
+           - ENV ANSIBLE_GALAXY_SERVER_AUTOMATION_HUB_TOKEN=$AH_TOKEN
+   ```
+
+9. **If ansible.cfg needed at runtime**: also ADD in `append_final` (see rule 03). The galaxy stage copy is discarded.
+
+10. **If targeting legacy network devices on RHEL 9**: add crypto policy workaround in `append_final` (see rule 05)
+
+11. **Set package_manager_path**
+    ```yaml
+    options:
+        package_manager_path: /usr/bin/microdnf
+    ```
+
+12. **Use version: 3** for the execution-environment.yml format. Version 1 and 2 are legacy.
+
+13. **Test locally**
+    ```bash
+    ansible-builder build -f <dir>/execution-environment.yml -t test:latest -v 3 --build-arg AH_TOKEN=<token>
+    ```
+
+14. **No CI changes needed**: `generate_matrix.py` auto-detects new directories with `execution-environment.yml`.
+
+## Directory Structure
+
+```
+my-new-ee/
+  execution-environment.yml    # Required
+  requirements.yml             # Galaxy collections
+  requirements.txt             # Python pip packages
+  bindep.txt                   # System RPM packages
+  ansible.cfg                  # Galaxy server config (copy from existing EE)
+```
+
+File naming varies across EEs (`ansible-collections.yml` vs `requirements.yml`, `python-packages.txt` vs `requirements.txt`). Match the convention of similar EEs or use the names above.

--- a/.github/workflows/test-ee-build.yml
+++ b/.github/workflows/test-ee-build.yml
@@ -1,0 +1,58 @@
+name: Test EE Builds
+
+on:
+  pull_request:
+    branches:
+      - main
+    types: [opened, reopened, synchronize]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-test-ees:
+    runs-on: ubuntu-latest
+    environment: test
+    strategy:
+      matrix:
+        ee:
+          - tests/test-ee-aap27-minimal
+          - tests/test-ee-aap26-minimal
+          - tests/test-ee-aap26-supported
+          - tests/test-ee-source-only-pkg
+      fail-fast: false
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Install ansible-builder
+        run: pip install -r requirements.txt
+
+      - name: Log in to registry.redhat.io
+        uses: redhat-actions/podman-login@v1
+        with:
+          registry: registry.redhat.io
+          username: ${{ secrets.REDHAT_SA_USERNAME }}
+          password: ${{ secrets.REDHAT_SA_PASSWORD }}
+
+      - name: Substitute token for automation hub
+        run: |
+          sed -i "s/my_ah_token/${{ secrets.AH_TOKEN }}/g" ansible.cfg
+
+      - name: Build test EE
+        working-directory: ${{ matrix.ee }}
+        run: |
+          ansible-builder build -v 3 \
+            --build-arg AH_TOKEN=${{ secrets.AH_TOKEN }} \
+            --tag=test-$(basename ${{ matrix.ee }}):${{ github.sha }}
+
+      - name: Verify image
+        run: |
+          IMAGE="test-$(basename ${{ matrix.ee }}):${{ github.sha }}"
+          echo "## Test: $(basename ${{ matrix.ee }})" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          podman run --rm $IMAGE python3 --version >> $GITHUB_STEP_SUMMARY
+          podman run --rm $IMAGE ansible --version >> $GITHUB_STEP_SUMMARY
+          podman run --rm $IMAGE ansible-galaxy collection list >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,7 +101,7 @@ Images live in `registry.redhat.io/ansible-automation-platform-<aap-version>/`. 
 | 25 | rhel9 | 2.16.17 | 3.12.12 | 3.1.6 |
 | 26 | rhel9 | 2.16.18 | 3.12.12 | 3.1.6 |
 
-### de-minimal (Development Environments — minimal base)
+### de-minimal (Decision Environments for EDA — minimal base)
 
 | AAP | RHEL | ansible-core | Python | Jinja |
 |-----|------|-------------|--------|-------|
@@ -111,7 +111,7 @@ Images live in `registry.redhat.io/ansible-automation-platform-<aap-version>/`. 
 | 25 | rhel9 | 2.16.15 | 3.11.13 | 3.1.6 |
 | 26 | rhel9 | 2.16.18 | 3.12.12 | 3.1.6 |
 
-### de-supported (Development Environments — with pre-bundled collections)
+### de-supported (Decision Environments for EDA — with pre-bundled collections)
 
 | AAP | RHEL | ansible-core | Python | Jinja |
 |-----|------|-------------|--------|-------|
@@ -136,6 +136,31 @@ collections:
   - name: cisco.asa          # not in ee-supported
   # Do NOT add cisco.ios, ansible.netcommon — they ship with the base
 ```
+
+## PYCMD Hijack on RHEL 9
+
+On RHEL 9 ee-minimal images, `microdnf` pulls in `python3-3.9` as a transitive dependency when installing system packages. This takes over `/usr/bin/python3` from Python 3.12, breaking pip, wheel compilation, and the final image.
+
+Fix: pin `PYCMD` in both builder and final stages. For AAP 2.7, also reinstall builder script dependencies for Python 3.12.
+
+```yaml
+# AAP 2.6 ee-minimal-rhel9
+prepend_builder:
+    - ENV PYCMD=/usr/bin/python3.12
+prepend_final:
+    - ENV PYCMD=/usr/bin/python3.12
+
+# AAP 2.7 ee-minimal-rhel9 (also needs builder deps reinstall)
+prepend_builder:
+    - ENV PYCMD=/usr/bin/python3.12
+    - RUN $PYCMD -m pip install --upgrade pip setuptools requirements-parser bindep pyyaml distro packaging Parsley
+prepend_final:
+    - ENV PYCMD=/usr/bin/python3.12
+```
+
+The `python3.XX-devel` package in bindep.txt must match the active Python (e.g., `python3.12-devel` for AAP 2.6/2.7 on RHEL 9).
+
+See `.claude/rules/01-python-version-pitfalls.md` for full details.
 
 ## pip Build Isolation
 
@@ -170,16 +195,40 @@ Only EE directories with changed files between the base and head refs are built.
 1. Create a new directory at the repo root (name = image name, use lowercase with hyphens or underscores).
 2. Add `execution-environment.yml` (version 3) pointing to the desired base image.
 3. Add dependency files as needed (`requirements.yml`, `requirements.txt`/`python-packages.txt`, `bindep.txt`).
-4. Copy `ansible.cfg` from an existing EE (contains Galaxy server config with `my_ah_token` placeholder).
-5. Add `ansible.cfg` to `additional_build_files` in the EE definition.
-6. No workflow changes needed.
+4. If RHEL 9 ee-minimal: add `ENV PYCMD=/usr/bin/python3.12` in `prepend_builder` and `prepend_final`. If AAP 2.7, also reinstall builder script deps.
+5. Ensure `python3.XX-devel` in `bindep.txt` matches the active Python (e.g., `python3.12-devel` for AAP 2.6/2.7 rhel9).
+6. Copy `ansible.cfg` from an existing EE (contains Galaxy server config with `my_ah_token` placeholder).
+7. Add `ansible.cfg` to `additional_build_files` in the EE definition.
+8. No workflow changes needed.
 
 ## Debugging EE Builds
 
 | Symptom | Cause | Fix |
 |---------|-------|-----|
+| `fatal error: Python.h: No such file or directory` | Missing or wrong python-devel | Add `python3.12-devel` (must match active Python) to bindep.txt |
+| `ModuleNotFoundError: No module named 'requirements'` | PYCMD overridden but builder scripts not reinstalled (AAP 2.7) | Add `RUN $PYCMD -m pip install ... requirements-parser bindep pyyaml distro packaging Parsley` in prepend_builder |
+| `No module named 'ansible'` in check_ansible | Final image python3 points to 3.9 but ansible installed under 3.12 | Set `ENV PYCMD=/usr/bin/python3.12` in prepend_final |
+| `No module named setuptools` | pip 24+ build isolation with source-only package | Pin `pip<24`, set `ENV PIP_NO_BUILD_ISOLATION=1`, or don't upgrade pip |
+| Wheels downloaded as `cp39` instead of `cp312` | PYCMD hijacked to Python 3.9 | Set `ENV PYCMD=/usr/bin/python3.12` in prepend_builder and prepend_final |
+| `No package matches 'openshift-clients'` | `kubernetes.core` bindep requires OCP repo | Use `dependencies.exclude.system` or enable repo via PKGMGR_OPTS |
 | Build failure in galaxy stage | Automation Hub auth | Check AH_TOKEN, network connectivity |
-| `No module named setuptools` | pip build isolation (ansible-builder >=3.1) | Stay on `ansible-builder==3.0.0` or set `ENV PIP_NO_BUILD_ISOLATION=1` in `prepend_base` |
-| `No module named pip` | microdnf removed pip | Add `python3-pip` to `bindep.txt` + `RUN $PYCMD -m ensurepip` in `prepend_base` |
-| Collection version warnings at runtime | Build overwrites base image's ansible.cfg | Use `ENV ANSIBLE_COLLECTIONS_ON_ANSIBLE_VERSION_MISMATCH=ignore` in `prepend_base` (not ansible.cfg in galaxy stage) |
+| Collection version warnings at runtime | ee-supported collections declare higher ansible-core | `ENV ANSIBLE_COLLECTIONS_ON_ANSIBLE_VERSION_MISMATCH=ignore` in prepend_base |
 | Collections pulling wrong versions | Overriding base image collections | Trim `requirements.yml` to delta-only |
+
+See `.claude/rules/06-debugging-builds.md` for the full reference table.
+
+## Test EEs
+
+The `tests/` directory contains regression test EEs that exercise the pitfalls documented in `.claude/rules/`. All four test EEs build on every PR via `.github/workflows/test-ee-build.yml`. See `tests/README.md` for details.
+
+## Detailed Rules
+
+| Rule File | Topic |
+|-----------|-------|
+| `.claude/rules/01-python-version-pitfalls.md` | PYCMD hijack, python-devel matching, builder deps |
+| `.claude/rules/02-pip-build-isolation.md` | pip upgrade trap, source-only packages |
+| `.claude/rules/03-multi-stage-build-mechanics.md` | Stage persistence, ENV/file placement |
+| `.claude/rules/04-base-image-selection.md` | AAP/RHEL matrix, ee-minimal vs ee-supported |
+| `.claude/rules/05-common-workarounds.md` | Legacy crypto, PIP_IGNORE_INSTALLED, openshift-clients |
+| `.claude/rules/06-debugging-builds.md` | Symptom/cause/fix reference table |
+| `.claude/rules/07-adding-new-ees.md` | New EE checklist with all pitfalls |

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,26 @@
+# Test Execution Environments
+
+Regression tests for known EE build pitfalls documented in `.claude/rules/`.
+
+## Test Matrix
+
+| Test EE | Base Image | Rules Tested | Pitfall Validated |
+|---------|-----------|-------------|-------------------|
+| `test-ee-aap27-minimal` | AAP 2.7 ee-minimal-rhel9 | 01 (A, B, C) | PYCMD hijack + builder deps reinstall + python3.12-devel + C extension |
+| `test-ee-aap26-minimal` | AAP 2.6 ee-minimal-rhel9 | 01 (A) | PYCMD hijack without builder deps reinstall |
+| `test-ee-aap26-supported` | AAP 2.6 ee-supported-rhel9 | 04, 05 | Delta-only collections, version mismatch suppression |
+| `test-ee-source-only-pkg` | AAP 2.6 ee-minimal-rhel9 | 02 | pip<24 pin prevents build isolation failure with systemd-python |
+
+## Running Locally
+
+```bash
+# From repo root
+ansible-builder build \
+  -f tests/<test-dir>/execution-environment.yml \
+  -t test:latest -v 3 \
+  --build-arg AH_TOKEN=<your-token>
+```
+
+## CI
+
+These test EEs are built on every PR via `.github/workflows/test-ee-build.yml`. All four test EEs build on every PR regardless of which files changed, serving as regression tests for the documented rules.

--- a/tests/test-ee-aap26-minimal/ansible.cfg
+++ b/tests/test-ee-aap26-minimal/ansible.cfg
@@ -1,0 +1,13 @@
+[galaxy]
+server_list = automation_hub, automation_hub_validated, release_galaxy
+
+[galaxy_server.automation_hub]
+url=https://console.redhat.com/api/automation-hub/content/published/
+auth_url=https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
+
+[galaxy_server.automation_hub_validated]
+url=https://console.redhat.com/api/automation-hub/content/validated/
+auth_url=https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
+
+[galaxy_server.release_galaxy]
+url=https://galaxy.ansible.com/

--- a/tests/test-ee-aap26-minimal/bindep.txt
+++ b/tests/test-ee-aap26-minimal/bindep.txt
@@ -1,0 +1,2 @@
+python3.12-devel [compile platform:rhel-9]
+gcc [compile platform:rhel-9]

--- a/tests/test-ee-aap26-minimal/execution-environment.yml
+++ b/tests/test-ee-aap26-minimal/execution-environment.yml
@@ -1,0 +1,30 @@
+---
+# TEST: AAP 2.6 ee-minimal-rhel9 (PYCMD workaround only)
+# Validates: PYCMD hijack fix works on AAP 2.6 WITHOUT builder deps reinstall
+# Rules tested: 01-A
+version: 3
+images:
+  base_image:
+    name: registry.redhat.io/ansible-automation-platform-26/ee-minimal-rhel9:latest
+
+dependencies:
+  galaxy: requirements.yml
+  python: requirements.txt
+  system: bindep.txt
+
+additional_build_files:
+    - src: ansible.cfg
+      dest: configs
+
+options:
+    package_manager_path: /usr/bin/microdnf
+
+additional_build_steps:
+    prepend_builder:
+        - ENV PYCMD=/usr/bin/python3.12
+    prepend_final:
+        - ENV PYCMD=/usr/bin/python3.12
+    prepend_galaxy:
+        - ADD _build/configs/ansible.cfg /etc/ansible/ansible.cfg
+        - ARG AH_TOKEN
+        - ENV ANSIBLE_GALAXY_SERVER_AUTOMATION_HUB_TOKEN=$AH_TOKEN

--- a/tests/test-ee-aap26-minimal/requirements.txt
+++ b/tests/test-ee-aap26-minimal/requirements.txt
@@ -1,0 +1,3 @@
+# pyyaml has an optional C extension, netaddr is pure Python
+pyyaml
+netaddr

--- a/tests/test-ee-aap26-minimal/requirements.yml
+++ b/tests/test-ee-aap26-minimal/requirements.yml
@@ -1,0 +1,3 @@
+---
+collections:
+  - name: ansible.posix

--- a/tests/test-ee-aap26-supported/ansible.cfg
+++ b/tests/test-ee-aap26-supported/ansible.cfg
@@ -1,0 +1,13 @@
+[galaxy]
+server_list = automation_hub, automation_hub_validated, release_galaxy
+
+[galaxy_server.automation_hub]
+url=https://console.redhat.com/api/automation-hub/content/published/
+auth_url=https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
+
+[galaxy_server.automation_hub_validated]
+url=https://console.redhat.com/api/automation-hub/content/validated/
+auth_url=https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
+
+[galaxy_server.release_galaxy]
+url=https://galaxy.ansible.com/

--- a/tests/test-ee-aap26-supported/bindep.txt
+++ b/tests/test-ee-aap26-supported/bindep.txt
@@ -1,1 +1,5 @@
-# ee-supported has most system deps already — minimal additions
+# servicenow.itsm pulls in systemd-python (C extension) transitively
+python3.12-devel [compile platform:rhel-9]
+systemd-devel [compile platform:rhel-9]
+pkgconf-pkg-config [compile platform:rhel-9]
+gcc [compile platform:rhel-9]

--- a/tests/test-ee-aap26-supported/bindep.txt
+++ b/tests/test-ee-aap26-supported/bindep.txt
@@ -1,0 +1,1 @@
+# ee-supported has most system deps already — minimal additions

--- a/tests/test-ee-aap26-supported/execution-environment.yml
+++ b/tests/test-ee-aap26-supported/execution-environment.yml
@@ -1,0 +1,28 @@
+---
+# TEST: AAP 2.6 ee-supported-rhel9 (delta-only deps)
+# Validates: Delta-only collections on ee-supported, version mismatch suppression
+# Rules tested: 04, 05
+version: 3
+images:
+  base_image:
+    name: registry.redhat.io/ansible-automation-platform-26/ee-supported-rhel9:latest
+
+dependencies:
+  galaxy: requirements.yml
+  system: bindep.txt
+
+additional_build_files:
+    - src: ansible.cfg
+      dest: configs
+
+options:
+    package_manager_path: /usr/bin/microdnf
+
+additional_build_steps:
+    prepend_base:
+        - ENV ANSIBLE_COLLECTIONS_ON_ANSIBLE_VERSION_MISMATCH=ignore
+    prepend_galaxy:
+        - ADD _build/configs/ansible.cfg /etc/ansible/ansible.cfg
+        - ARG AH_TOKEN
+        - ENV ANSIBLE_GALAXY_SERVER_AUTOMATION_HUB_TOKEN=$AH_TOKEN
+        - ENV ANSIBLE_GALAXY_SERVER_AUTOMATION_HUB_VALIDATED_TOKEN=$AH_TOKEN

--- a/tests/test-ee-aap26-supported/execution-environment.yml
+++ b/tests/test-ee-aap26-supported/execution-environment.yml
@@ -21,6 +21,10 @@ options:
 additional_build_steps:
     prepend_base:
         - ENV ANSIBLE_COLLECTIONS_ON_ANSIBLE_VERSION_MISMATCH=ignore
+    prepend_builder:
+        - ENV PYCMD=/usr/bin/python3.12
+    prepend_final:
+        - ENV PYCMD=/usr/bin/python3.12
     prepend_galaxy:
         - ADD _build/configs/ansible.cfg /etc/ansible/ansible.cfg
         - ARG AH_TOKEN

--- a/tests/test-ee-aap26-supported/requirements.yml
+++ b/tests/test-ee-aap26-supported/requirements.yml
@@ -1,0 +1,5 @@
+---
+# Delta-only: ONLY collections NOT already in ee-supported-rhel9
+# Do NOT add cisco.ios, ansible.netcommon, ansible.utils, etc.
+collections:
+  - name: servicenow.itsm

--- a/tests/test-ee-aap27-minimal/ansible.cfg
+++ b/tests/test-ee-aap27-minimal/ansible.cfg
@@ -1,0 +1,13 @@
+[galaxy]
+server_list = automation_hub, automation_hub_validated, release_galaxy
+
+[galaxy_server.automation_hub]
+url=https://console.redhat.com/api/automation-hub/content/published/
+auth_url=https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
+
+[galaxy_server.automation_hub_validated]
+url=https://console.redhat.com/api/automation-hub/content/validated/
+auth_url=https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
+
+[galaxy_server.release_galaxy]
+url=https://galaxy.ansible.com/

--- a/tests/test-ee-aap27-minimal/bindep.txt
+++ b/tests/test-ee-aap27-minimal/bindep.txt
@@ -1,0 +1,4 @@
+python3.12-devel [compile platform:rhel-9]
+systemd-devel [compile platform:rhel-9]
+pkgconf-pkg-config [compile platform:rhel-9]
+gcc [compile platform:rhel-9]

--- a/tests/test-ee-aap27-minimal/execution-environment.yml
+++ b/tests/test-ee-aap27-minimal/execution-environment.yml
@@ -5,7 +5,7 @@
 version: 3
 images:
   base_image:
-    name: registry.redhat.io/ansible-automation-platform-27/ee-minimal-rhel9:latest
+    name: registry.redhat.io/ansible-automation-platform-27/ee-minimal-rhel9:2.16
 
 dependencies:
   galaxy: requirements.yml

--- a/tests/test-ee-aap27-minimal/execution-environment.yml
+++ b/tests/test-ee-aap27-minimal/execution-environment.yml
@@ -1,0 +1,31 @@
+---
+# TEST: AAP 2.7 ee-minimal-rhel9 (hardest case)
+# Validates: PYCMD hijack fix, builder deps reinstall, python3.12-devel, C extension build
+# Rules tested: 01-A, 01-B, 01-C
+version: 3
+images:
+  base_image:
+    name: registry.redhat.io/ansible-automation-platform-27/ee-minimal-rhel9:latest
+
+dependencies:
+  galaxy: requirements.yml
+  python: requirements.txt
+  system: bindep.txt
+
+additional_build_files:
+    - src: ansible.cfg
+      dest: configs
+
+options:
+    package_manager_path: /usr/bin/microdnf
+
+additional_build_steps:
+    prepend_builder:
+        - ENV PYCMD=/usr/bin/python3.12
+        - RUN $PYCMD -m pip install --upgrade pip setuptools requirements-parser bindep pyyaml distro packaging Parsley
+    prepend_final:
+        - ENV PYCMD=/usr/bin/python3.12
+    prepend_galaxy:
+        - ADD _build/configs/ansible.cfg /etc/ansible/ansible.cfg
+        - ARG AH_TOKEN
+        - ENV ANSIBLE_GALAXY_SERVER_AUTOMATION_HUB_TOKEN=$AH_TOKEN

--- a/tests/test-ee-aap27-minimal/requirements.txt
+++ b/tests/test-ee-aap27-minimal/requirements.txt
@@ -1,0 +1,5 @@
+# systemd-python is source-only (C extension) — exercises:
+# 1. python3.12-devel must be in bindep.txt
+# 2. systemd-devel must be in bindep.txt
+# 3. Build must NOT upgrade pip (source-only + pip 24+ = failure)
+systemd-python

--- a/tests/test-ee-aap27-minimal/requirements.yml
+++ b/tests/test-ee-aap27-minimal/requirements.yml
@@ -1,0 +1,3 @@
+---
+collections:
+  - name: ansible.posix

--- a/tests/test-ee-source-only-pkg/ansible.cfg
+++ b/tests/test-ee-source-only-pkg/ansible.cfg
@@ -1,0 +1,13 @@
+[galaxy]
+server_list = automation_hub, automation_hub_validated, release_galaxy
+
+[galaxy_server.automation_hub]
+url=https://console.redhat.com/api/automation-hub/content/published/
+auth_url=https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
+
+[galaxy_server.automation_hub_validated]
+url=https://console.redhat.com/api/automation-hub/content/validated/
+auth_url=https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
+
+[galaxy_server.release_galaxy]
+url=https://galaxy.ansible.com/

--- a/tests/test-ee-source-only-pkg/bindep.txt
+++ b/tests/test-ee-source-only-pkg/bindep.txt
@@ -1,0 +1,4 @@
+python3.12-devel [compile platform:rhel-9]
+systemd-devel [compile platform:rhel-9]
+pkgconf-pkg-config [compile platform:rhel-9]
+gcc [compile platform:rhel-9]

--- a/tests/test-ee-source-only-pkg/execution-environment.yml
+++ b/tests/test-ee-source-only-pkg/execution-environment.yml
@@ -1,0 +1,34 @@
+---
+# TEST: pip build isolation with source-only package
+# Validates: pip<24 pin prevents PEP 517 build isolation failure
+# Rules tested: 02
+version: 3
+images:
+  base_image:
+    name: registry.redhat.io/ansible-automation-platform-26/ee-minimal-rhel9:latest
+
+dependencies:
+  galaxy: requirements.yml
+  python: requirements.txt
+  system: bindep.txt
+
+additional_build_files:
+    - src: ansible.cfg
+      dest: configs
+
+options:
+    package_manager_path: /usr/bin/microdnf
+
+additional_build_steps:
+    prepend_base:
+        # Pin pip below 24 to avoid PEP 517 build isolation
+        # Without this pin, systemd-python fails: "No module named setuptools"
+        - RUN $PYCMD -m pip install 'pip<24' setuptools
+    prepend_builder:
+        - ENV PYCMD=/usr/bin/python3.12
+    prepend_final:
+        - ENV PYCMD=/usr/bin/python3.12
+    prepend_galaxy:
+        - ADD _build/configs/ansible.cfg /etc/ansible/ansible.cfg
+        - ARG AH_TOKEN
+        - ENV ANSIBLE_GALAXY_SERVER_AUTOMATION_HUB_TOKEN=$AH_TOKEN

--- a/tests/test-ee-source-only-pkg/requirements.txt
+++ b/tests/test-ee-source-only-pkg/requirements.txt
@@ -1,0 +1,3 @@
+# Source-only package (no pre-built wheel on PyPI)
+# Fails if pip >= 24 with build isolation enabled
+systemd-python

--- a/tests/test-ee-source-only-pkg/requirements.yml
+++ b/tests/test-ee-source-only-pkg/requirements.yml
@@ -1,0 +1,3 @@
+---
+collections:
+  - name: ansible.posix


### PR DESCRIPTION
## Summary
- Add `.claude/rules/` with 7 rule files covering all known EE build pitfalls (PYCMD hijack, python-devel matching, pip build isolation, multi-stage mechanics, base image selection, common workarounds, debugging, new EE checklist)
- Add `tests/` with 4 regression test EEs exercising the documented rules:
  - `test-ee-aap27-minimal`: PYCMD + builder deps reinstall + C extension (hardest case)
  - `test-ee-aap26-minimal`: PYCMD workaround only
  - `test-ee-aap26-supported`: delta-only deps on ee-supported
  - `test-ee-source-only-pkg`: pip<24 pin for build isolation
- Add `.github/workflows/test-ee-build.yml` to build all test EEs on every PR
- Update `CLAUDE.md` with PYCMD section, expanded debugging table, rules index, test EEs section, DE label fix (Decision Environments for EDA, not Development)

## Test plan
- [ ] Confirm test-ee-build workflow triggers and all 4 test EEs build
- [ ] Confirm devel build workflow still works for production EEs