### PR TITLE
fix: exclude tests/ from prod build matrix

### DIFF
--- a/.github/workflows/generate_matrix.py
+++ b/.github/workflows/generate_matrix.py
@@ -60,8 +60,12 @@ def main():
     changed_files = get_changed_files(args.start_ref, end_ref, logger)
     dirs = set()
 
+    excluded_prefixes = ('tests/', '.github/', '.claude/')
     for file in changed_files:
         dir_name = os.path.dirname(file)
+        if any(dir_name.startswith(prefix) for prefix in excluded_prefixes):
+            logger.info(f"Skipping excluded directory: {dir_name}")
+            continue
         ee_file_path = os.path.join(os.getenv('GITHUB_WORKSPACE', ''), dir_name, "execution-environment.yml")
         if dir_name not in dirs and os.path.isfile(ee_file_path):
             logger.info(f"EE file found: {ee_file_path}")


### PR DESCRIPTION
The merge of #131 added test EE directories under tests/. The generate_matrix.py script detected them as changed EE directories and the prod workflow tried to build and push them to quay.io. This adds an exclusion for tests/, .github/, and .claude/ prefixes.