### PR TITLE
fix: make test EE workflow manual trigger only

### DIFF
--- a/.github/workflows/test-ee-build.yml
+++ b/.github/workflows/test-ee-build.yml
@@ -1,10 +1,6 @@
 name: Test EE Builds
 
 on:
-  pull_request:
-    branches:
-      - main
-    types: [opened, reopened, synchronize]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Test EE builds are regression tests, not needed on every PR. Changed to workflow_dispatch only so they run when explicitly triggered from the Actions tab.