### PR TITLE
feat: add network_de decision environment on RHEL 9

### DIFF
--- a/network_de/ansible-collections.yml
+++ b/network_de/ansible-collections.yml
@@ -1,0 +1,3 @@
+---
+collections:
+  - name: ansible.eda

--- a/network_de/ansible.cfg
+++ b/network_de/ansible.cfg
@@ -1,0 +1,9 @@
+[galaxy]
+server_list = automation_hub, release_galaxy
+
+[galaxy_server.automation_hub]
+url=https://console.redhat.com/api/automation-hub/content/published/
+auth_url=https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
+
+[galaxy_server.release_galaxy]
+url=https://galaxy.ansible.com/

--- a/network_de/execution-environment.yml
+++ b/network_de/execution-environment.yml
@@ -18,6 +18,7 @@ options:
 
 additional_build_steps:
     prepend_base:
+        - ENV PIP_NO_BUILD_ISOLATION=1
         - RUN $PYCMD -m pip install --upgrade pip setuptools
     prepend_galaxy:
         - ADD _build/configs/ansible.cfg /etc/ansible/ansible.cfg

--- a/network_de/execution-environment.yml
+++ b/network_de/execution-environment.yml
@@ -1,0 +1,27 @@
+---
+version: 3
+images:
+    base_image:
+        name: 'registry.redhat.io/ansible-automation-platform-25/de-minimal-rhel9:latest'
+
+additional_build_files:
+    - src: ansible.cfg
+      dest: configs
+
+dependencies:
+    galaxy: ansible-collections.yml
+    python: python-packages.txt
+    system: system-packages.txt
+
+options:
+    package_manager_path: /usr/bin/microdnf
+
+additional_build_steps:
+    prepend_base:
+        - RUN $PYCMD -m pip install --upgrade pip setuptools
+    prepend_galaxy:
+        - ADD _build/configs/ansible.cfg /etc/ansible/ansible.cfg
+        - ARG AH_TOKEN
+        - ENV ANSIBLE_GALAXY_SERVER_AUTOMATION_HUB_TOKEN=$AH_TOKEN
+    append_final:
+        - RUN rm -f /etc/ansible/ansible.cfg

--- a/network_de/python-packages.txt
+++ b/network_de/python-packages.txt
@@ -1,0 +1,1 @@
+aiomqtt

--- a/network_de/system-packages.txt
+++ b/network_de/system-packages.txt
@@ -1,0 +1,4 @@
+pkgconf-pkg-config [platform:rpm]
+systemd-devel [platform:rpm]
+gcc [platform:rpm]
+python3.11-devel [platform:rpm]

--- a/network_de/system-packages.txt
+++ b/network_de/system-packages.txt
@@ -1,4 +1,4 @@
 pkgconf-pkg-config [platform:rpm]
 systemd-devel [platform:rpm]
 gcc [platform:rpm]
-python3.11-devel [platform:rpm]
+python3.12-devel [platform:rpm]


### PR DESCRIPTION
## Summary

- Adds `network_de` decision environment definition, rebased from RHEL 8 to RHEL 9
- Replaces `de-minimal-rhel8` (AAP 2.5) base with `de-minimal-rhel9` (AAP 2.5, RHEL 9.8)
- Addresses CVE affecting the EDA WebSocket API on RHEL 8
- Used by the `ai-driven-automation` lab (`openshift_cnv/ai-driven-automation/common.yaml`) as the EDA decision environment

## Context

The existing image `quay.io/nmartins/network_de` was built on RHEL 8.10 with no committed definition files. These definitions were reverse-engineered from the published container image and rebased onto the RHEL 9 base.

The RHEL 9 base (`de-minimal-rhel9`) already includes `aiokafka`, `kafka-python-ng`, `azure-servicebus`, `psycopg`, and all other dependencies. The only additional pip package needed is `aiomqtt` for MQTT-based EDA event sources.

## Changes

| Property | Old (nmartins/network_de) | New |
|----------|--------------------------|-----|
| Base image | `de-minimal-rhel8` (AAP 2.5) | `de-minimal-rhel9` (AAP 2.5) |
| Base OS | RHEL 8.10 | RHEL 9.8 |
| ansible-core | 2.16.11 | 2.16.19 |
| ansible-rulebook | 1.1.1 | 1.2.2 |

## Test plan

- [ ] Build the DE using `ansible-builder build` from the `network_de/` directory
- [ ] Verify the built image runs on RHEL 9 (`cat /etc/os-release`)
- [ ] Deploy to `ai-driven-automation` lab and verify EDA activations (Web App, OSPF/Splunk, Windows/Kafka) start successfully