### PR TITLE
feat: add cisco-ee with Catalyst Center and Meraki

### DIFF
--- a/cisco-ee/ansible.cfg
+++ b/cisco-ee/ansible.cfg
@@ -1,0 +1,13 @@
+[galaxy]
+server_list = automation_hub, automation_hub_validated, release_galaxy
+
+[galaxy_server.automation_hub]
+url=https://console.redhat.com/api/automation-hub/content/published/
+auth_url=https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
+
+[galaxy_server.automation_hub_validated]
+url=https://console.redhat.com/api/automation-hub/content/validated/
+auth_url=https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
+
+[galaxy_server.release_galaxy]
+url=https://galaxy.ansible.com/

--- a/cisco-ee/execution-environment.yml
+++ b/cisco-ee/execution-environment.yml
@@ -1,0 +1,28 @@
+---
+version: 3
+images:
+  base_image:
+    name: registry.redhat.io/ansible-automation-platform-26/ee-supported-rhel9:latest
+
+dependencies:
+  galaxy: requirements.yml
+
+additional_build_files:
+    - src: ansible.cfg
+      dest: configs
+
+options:
+    package_manager_path: /usr/bin/microdnf
+
+additional_build_steps:
+    prepend_base:
+        - ENV ANSIBLE_COLLECTIONS_ON_ANSIBLE_VERSION_MISMATCH=ignore
+    prepend_builder:
+        - ENV PYCMD=/usr/bin/python3.12
+    prepend_final:
+        - ENV PYCMD=/usr/bin/python3.12
+    prepend_galaxy:
+        - ADD _build/configs/ansible.cfg /etc/ansible/ansible.cfg
+        - ARG AH_TOKEN
+        - ENV ANSIBLE_GALAXY_SERVER_AUTOMATION_HUB_TOKEN=$AH_TOKEN
+        - ENV ANSIBLE_GALAXY_SERVER_AUTOMATION_HUB_VALIDATED_TOKEN=$AH_TOKEN

--- a/cisco-ee/requirements.yml
+++ b/cisco-ee/requirements.yml
@@ -1,0 +1,4 @@
+---
+collections:
+  - name: cisco.catalystcenter
+  - name: cisco.meraki


### PR DESCRIPTION
## Summary
- New `cisco-ee` execution environment based on AAP 2.6 ee-supported-rhel9
- Adds delta-only collections: `cisco.catalystcenter` and `cisco.meraki`
- Both are signed, certified collections from Automation Hub
- No bindep/python deps needed — both use pure Python SDK wheels

## Test plan
- [ ] CI builds the EE successfully (Devel EE Build workflow)
- [ ] Verify `cisco.catalystcenter` and `cisco.meraki` are installed in the built image

Assisted-by: Claude Opus 4.6