### PR TITLE
fix(cisco-ee): add compile deps for systemd-python

### DIFF
--- a/cisco-ee/bindep.txt
+++ b/cisco-ee/bindep.txt
@@ -1,0 +1,4 @@
+python3.12-devel [compile platform:rhel-9]
+systemd-devel [compile platform:rhel-9]
+pkgconf-pkg-config [compile platform:rhel-9]
+gcc [compile platform:rhel-9]

--- a/cisco-ee/execution-environment.yml
+++ b/cisco-ee/execution-environment.yml
@@ -6,6 +6,7 @@ images:
 
 dependencies:
   galaxy: requirements.yml
+  system: bindep.txt
 
 additional_build_files:
     - src: ansible.cfg


### PR DESCRIPTION
## Summary
- Adds `bindep.txt` with compile dependencies (`systemd-devel`, `gcc`, `python3.12-devel`, `pkgconf-pkg-config`)
- The ee-supported base re-introspects collection deps and tries to rebuild `systemd-python` from source, which needs these packages
- Fixes the prod build failure from #137

## Test plan
- [ ] CI builds cisco-ee successfully

Assisted-by: Claude Opus 4.6