### PR TITLE
feat(rosa-ee): add ROSA lifecycle demo execution environment

### DIFF
--- a/.cursor/rules/network-ee.mdc
+++ b/.cursor/rules/network-ee.mdc
@@ -12,7 +12,7 @@ Used by the Ansible Network Automation Workshop (rhpds/zt-network-automation-wor
 
 ## Base Image: ee-supported-rhel9
 
-Collections require `ansible-core>=2.17.0`. `ee-minimal-rhel9` (Python 3.9) can't satisfy this. `ee-supported-rhel9` (Python 3.12, ansible-core 2.15.x RPM) works with pre-bundled collections.
+Collections require `ansible-core>=2.17.0`. `ee-minimal-rhel9` (Python 3.9) can't satisfy this. `ee-supported-rhel9` (Python 3.9, ansible-core 2.15.x RPM) works with pre-bundled collections.
 
 ## Delta-Only Dependencies
 
@@ -20,10 +20,20 @@ Collections require `ansible-core>=2.17.0`. `ee-minimal-rhel9` (Python 3.9) can'
 
 ## Collection Version Mismatch Warnings (Fixed)
 
-The base image's collections declare support for ansible-core >=2.17 but the image ships 2.15.x. Red Hat suppresses the resulting warnings in the stock image's ansible.cfg. Our custom ansible.cfg (used for galaxy server URLs during build) replaces the stock one in the galaxy stage, but that stage is discarded — so the stock suppression survives in the final image.
+`ENV ANSIBLE_COLLECTIONS_ON_ANSIBLE_VERSION_MISMATCH=ignore` in `prepend_base` suppresses warnings from collections declaring `ansible-core>=2.17` while the image ships 2.15.x. Must be an ENV var in `prepend_base` (stage 1) — ansible.cfg changes in `prepend_galaxy` (stage 2) are discarded.
 
-If warnings reappear, set `ENV ANSIBLE_COLLECTIONS_ON_ANSIBLE_VERSION_MISMATCH=ignore` in `prepend_base` (persists to the final image). Do NOT rely on ansible.cfg changes in `prepend_galaxy` — that stage is thrown away.
+## RHEL 9 Crypto Policy — ssh-rsa (Fixed, Temporary)
+
+RHEL 9 blocks `ssh-rsa` at the OS libssh C library level via `/etc/crypto-policies/back-ends/libssh.config`. Cisco IOS devices require `ssh-rsa`, causing `PUBLICKEY_ACCEPTED_TYPES` errors. Ansible-level config (`ansible.cfg`, ENV vars, host vars) cannot override this — the OS rejects the algorithm before Ansible sees it.
+
+**Fix**: `update-crypto-policies --set DEFAULT:SHA1` in `append_final` (stage 4).
+
+**Deprecation plan**: This workaround should be removed once the workshop lab routers are upgraded to support modern key algorithms (e.g. `ecdsa-sha2-nistp256`). When removing, delete the `update-crypto-policies` line from `append_final` and optionally the `ANSIBLE_LIBSSH_PUBLICKEY_ALGORITHMS` ENV var from `prepend_base`.
 
 ## ansible.cfg
 
-The `ansible.cfg` in this directory configures Automation Hub galaxy servers. It is `ADD`ed in `prepend_galaxy` and used only during `ansible-galaxy collection install`. It does **not** exist in the final runtime image (see multi-stage build notes in ee-build-conventions rule).
+The `ansible.cfg` has two roles:
+1. **Build-time** (stage 2 via `prepend_galaxy`): Galaxy server URLs for Automation Hub access during `ansible-galaxy collection install`
+2. **Runtime** (stage 4 via `append_final`): `[defaults]` and `[libssh_connection]` settings
+
+Both stages need the `ADD` because stage 2 is discarded after collection install.

--- a/.cursor/skills/ansible-ee-builds/SKILL.md
+++ b/.cursor/skills/ansible-ee-builds/SKILL.md
@@ -119,6 +119,32 @@ python3-pip    [platform:rhel-9] # microdnf can remove pip; ensure it's present
 - Automation Hub 504 timeouts are transient — rerun the workflow.
 - The workflow runs on merge to `main`. Use devel→main PRs.
 
+## RHEL 9 Crypto Policy and ssh-rsa
+
+RHEL 9's system crypto policy blocks `ssh-rsa` at the OS libssh C library
+level (`/etc/crypto-policies/back-ends/libssh.config`). This causes failures
+connecting to older network devices (e.g. Cisco IOS) that require `ssh-rsa`:
+
+```
+ssh connection failed: The key algorithm 'ssh-rsa' is not allowed to be used by PUBLICKEY_ACCEPTED_TYPES
+```
+
+Ansible-level config (`ansible.cfg`, ENV vars, host vars) cannot fix this —
+the OS rejects the algorithm before Ansible sees it.
+
+**Fix** — relax the crypto policy in `append_final`:
+
+```yaml
+append_final:
+    - RUN microdnf install -y crypto-policies-scripts && update-crypto-policies --set DEFAULT:SHA1 && microdnf clean all
+```
+
+Notes:
+- `crypto-policies-scripts` provides `update-crypto-policies` (not in base image)
+- `DEFAULT:SHA1` is a built-in RHEL 9 sub-policy — do NOT write custom `.pmod`
+  files with INI syntax (that's not the correct format)
+- The `.pmod` module format uses `key = value` without section headers
+
 ## Debugging Checklist
 
 When an EE build fails or produces runtime warnings:
@@ -128,3 +154,5 @@ When an EE build fails or produces runtime warnings:
 3. **`No module named pip`?** → Add `python3-pip` to bindep.txt + `RUN $PYCMD -m ensurepip` in prepend_base
 4. **Collection version warnings at runtime?** → Check if your build overwrites the base image's ansible.cfg; use ENV var in prepend_base instead
 5. **Collections pulling wrong versions?** → You're probably overriding base image collections in requirements.yml; trim to delta only
+6. **ssh-rsa / PUBLICKEY_ACCEPTED_TYPES error?** → RHEL 9 crypto policy blocks ssh-rsa at OS level; use `update-crypto-policies --set DEFAULT:SHA1` in append_final
+7. **`command not found` in append_final?** → Install the package first (e.g. `crypto-policies-scripts` for `update-crypto-policies`)

--- a/network-ee/README.md
+++ b/network-ee/README.md
@@ -1,0 +1,76 @@
+# network-ee
+
+Custom Ansible Execution Environment for the [Network Automation Workshop](https://github.com/rhpds/zt-network-automation-workshop).
+
+**Image**: `quay.io/acme_corp/network-ee:latest`
+
+## Base Image
+
+Built on `registry.redhat.io/ansible-automation-platform-26/ee-supported-rhel9:latest`, which ships:
+- Python 3.9, ansible-core 2.15.x (RPM)
+- Pre-bundled collections: `cisco.ios`, `arista.eos`, `junipernetworks.junos`, `ansible.netcommon`, `ansible.utils`, `ansible.controller`, `ansible.platform`, and more
+
+This EE adds only **delta** collections and packages not already in the base image.
+
+## Build
+
+Builds are triggered automatically by GitHub Actions on merge to `main`. To build locally:
+
+```bash
+pip install ansible-builder==3.0.0
+cd network-ee
+ansible-builder build --tag quay.io/acme_corp/network-ee:latest
+```
+
+> **Note**: `ansible-builder==3.0.0` is required. Newer versions change pip build isolation behavior and break source-only packages.
+
+## Key Build Details
+
+### ansible-builder v3 Multi-Stage Build
+
+`ansible-builder` v3 generates a 4-stage Containerfile. Only stages 1 (base) and 4 (final) persist into the runtime image. Files added in stage 2 (galaxy) — including `ansible.cfg` — are discarded after collection install. This is why:
+
+- **ENV vars** are set in `prepend_base` (stage 1) for runtime config
+- **`ansible.cfg`** is added in both `prepend_galaxy` (for build-time galaxy access) and `append_final` (for runtime)
+
+### Delta-Only Collections
+
+`requirements.yml` only lists collections **not** already in the base image. Do not add collections the base image ships (e.g. `cisco.ios`, `ansible.netcommon`) — overriding them causes version conflicts.
+
+### RHEL 9 ssh-rsa Crypto Policy (Temporary Workaround)
+
+RHEL 9's system crypto policy blocks `ssh-rsa` at the OS libssh C library level. The workshop's Cisco IOS lab routers require `ssh-rsa` for SSH authentication. Without the workaround, connections fail with:
+
+```
+ssh connection failed: Failed to authenticate public key: The key algorithm 'ssh-rsa'
+is not allowed to be used by PUBLICKEY_ACCEPTED_TYPES configuration option
+```
+
+This cannot be fixed with Ansible config alone (`ansible.cfg`, environment variables, or host vars) — the OS-level libssh library rejects the algorithm before Ansible is consulted.
+
+**Current fix** in `execution-environment.yml`:
+
+```yaml
+append_final:
+    - RUN microdnf install -y crypto-policies-scripts && update-crypto-policies --set DEFAULT:SHA1 && microdnf clean all
+```
+
+#### When to remove this workaround
+
+Remove the `update-crypto-policies` line and the `ANSIBLE_LIBSSH_PUBLICKEY_ALGORITHMS` ENV var once the lab router images are upgraded to support modern key exchange algorithms (e.g. `ecdsa-sha2-nistp256`, `ssh-ed25519`). To remove:
+
+1. Delete from `execution-environment.yml`:
+   - The `update-crypto-policies` line in `append_final`
+   - The `ENV ANSIBLE_LIBSSH_PUBLICKEY_ALGORITHMS=ssh-rsa` line in `prepend_base`
+2. Optionally remove the `[libssh_connection]` section from `ansible.cfg`
+3. Rebuild and test against the lab routers
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `execution-environment.yml` | ansible-builder v3 build definition |
+| `requirements.yml` | Delta Ansible collections (not in base image) |
+| `requirements.txt` | Delta Python packages (not in base image) |
+| `bindep.txt` | System packages for C extension compilation |
+| `ansible.cfg` | Galaxy server URLs (build-time) + runtime config |

--- a/rosa-ee/README.md
+++ b/rosa-ee/README.md
@@ -1,0 +1,123 @@
+# rosa-ee
+
+Ansible Execution Environment for **ROSA (Red Hat OpenShift Service on AWS) lifecycle demos** — create and destroy clusters only.
+
+**Image**: `quay.io/acme_corp/rosa-ee:latest`
+
+## What's Included
+
+| Tool | Purpose |
+|------|---------|
+| `rosa` CLI | Create, describe, and delete ROSA clusters |
+| `aws` CLI v2 | AWS authentication and resource queries |
+| `oc` client | OpenShift cluster interaction (optional convenience) |
+| `jq` | JSON parsing in shell tasks |
+| `amazon.aws` collection | Ansible modules for AWS |
+| `community.aws` collection | Extended AWS modules |
+| `ansible.controller` collection | AAP job template management |
+
+## Build
+
+### Prerequisites
+
+- `ansible-builder==3.0.0` (pinned in repo root `requirements.txt`)
+- Access to `registry.redhat.io` (Red Hat subscription)
+- Automation Hub token (for certified collections)
+
+### Build locally
+
+```bash
+cd rosa-ee
+
+# Set your Automation Hub token
+export AH_TOKEN=<your-token>
+
+ansible-builder build \
+  --tag quay.io/acme_corp/rosa-ee:latest \
+  --build-arg AH_TOKEN=$AH_TOKEN
+```
+
+### Push to Quay
+
+```bash
+podman login quay.io
+podman push quay.io/acme_corp/rosa-ee:latest
+```
+
+### Tag with date
+
+```bash
+podman tag quay.io/acme_corp/rosa-ee:latest quay.io/acme_corp/rosa-ee:$(date +%Y%m%d)
+podman push quay.io/acme_corp/rosa-ee:$(date +%Y%m%d)
+```
+
+## Smoke Test
+
+```bash
+podman run --rm quay.io/acme_corp/rosa-ee:latest rosa version
+podman run --rm quay.io/acme_corp/rosa-ee:latest aws --version
+podman run --rm quay.io/acme_corp/rosa-ee:latest jq --version
+podman run --rm quay.io/acme_corp/rosa-ee:latest oc version --client
+```
+
+## Required Credentials (Runtime)
+
+These are **never** baked into the image. Pass them as environment variables or AAP credentials at runtime.
+
+| Variable | Purpose |
+|----------|---------|
+| `AWS_ACCESS_KEY_ID` | AWS IAM access key |
+| `AWS_SECRET_ACCESS_KEY` | AWS IAM secret key |
+| `AWS_DEFAULT_REGION` | AWS region (e.g. `us-east-2`) |
+| `ROSA_TOKEN` | OCM token from https://console.redhat.com/openshift/token |
+
+## AAP Controller Setup
+
+1. **Add Execution Environment**:
+   - Name: `ROSA Lifecycle EE`
+   - Image: `quay.io/acme_corp/rosa-ee:latest`
+   - Pull: `Always`
+
+2. **Create Credential Types** (if not already present):
+   - **AWS**: Use built-in `Amazon Web Services` credential type
+   - **ROSA Token**: Custom credential type with `ROSA_TOKEN` injected as env var
+
+3. **Create Job Template**:
+   - Execution Environment: `ROSA Lifecycle EE`
+   - Credentials: AWS + ROSA Token
+   - Extra vars or survey for cluster name, region, etc.
+
+## ROSA Lifecycle Commands (Reference)
+
+```bash
+# Login
+rosa login --token=$ROSA_TOKEN
+
+# Create cluster (single-AZ, minimal for demo)
+rosa create cluster --cluster-name=demo-cluster \
+  --region=us-east-2 \
+  --replicas=2 \
+  --machine-pool-min-replicas=2 \
+  --sts --mode=auto --yes
+
+# Watch status
+rosa describe cluster --cluster=demo-cluster
+rosa logs install --cluster=demo-cluster --watch
+
+# Delete cluster
+rosa delete cluster --cluster=demo-cluster --yes
+rosa logs uninstall --cluster=demo-cluster --watch
+
+# Cleanup STS roles after delete
+rosa delete operator-roles -c <cluster-id> --yes
+rosa delete oidc-provider -c <cluster-id> --yes
+```
+
+## Scope
+
+This EE is intentionally minimal — **create and destroy only**. It does not include:
+- Application deployment tooling
+- Operator management
+- GitOps/ArgoCD integration
+
+For app lifecycle, use a separate EE with the full OpenShift collection stack.

--- a/rosa-ee/ansible.cfg
+++ b/rosa-ee/ansible.cfg
@@ -1,0 +1,13 @@
+[galaxy]
+server_list = automation_hub, automation_hub_validated, release_galaxy
+
+[galaxy_server.automation_hub]
+url=https://console.redhat.com/api/automation-hub/content/published/
+auth_url=https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
+
+[galaxy_server.automation_hub_validated]
+url=https://console.redhat.com/api/automation-hub/content/validated/
+auth_url=https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
+
+[galaxy_server.release_galaxy]
+url=https://galaxy.ansible.com/

--- a/rosa-ee/bindep.txt
+++ b/rosa-ee/bindep.txt
@@ -1,0 +1,2 @@
+python3-devel [compile platform:rhel-9]
+gcc [compile platform:rhel-9]

--- a/rosa-ee/execution-environment.yml
+++ b/rosa-ee/execution-environment.yml
@@ -1,0 +1,30 @@
+---
+version: 3
+images:
+  base_image:
+    name: registry.redhat.io/ansible-automation-platform-27/ee-minimal-rhel9:latest
+
+dependencies:
+  galaxy: requirements.yml
+  python: requirements.txt
+  system: bindep.txt
+
+additional_build_files:
+    - src: ansible.cfg
+      dest: configs
+
+options:
+    package_manager_path: /usr/bin/microdnf
+
+additional_build_steps:
+    prepend_base:
+        - RUN microdnf install -y python3-pip && python3 -m pip install --upgrade pip setuptools
+    prepend_galaxy:
+        - ADD _build/configs/ansible.cfg /etc/ansible/ansible.cfg
+        - ARG AH_TOKEN
+        - ENV ANSIBLE_GALAXY_SERVER_AUTOMATION_HUB_TOKEN=$AH_TOKEN
+    append_final:
+        - RUN microdnf install -y unzip tar gzip jq && microdnf clean all
+        - RUN curl -sL "https://github.com/openshift/rosa/releases/latest/download/rosa_Linux_x86_64.tar.gz" | tar -xz -C /usr/local/bin rosa && chmod +x /usr/local/bin/rosa
+        - RUN curl -sL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip && unzip -q /tmp/awscliv2.zip -d /tmp && /tmp/aws/install && rm -rf /tmp/aws /tmp/awscliv2.zip
+        - RUN curl -sL "https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux.tar.gz" | tar -xz -C /usr/local/bin oc kubectl && chmod +x /usr/local/bin/oc /usr/local/bin/kubectl

--- a/rosa-ee/requirements.txt
+++ b/rosa-ee/requirements.txt
@@ -1,0 +1,3 @@
+boto3>=1.28.0
+botocore>=1.31.0
+requests

--- a/rosa-ee/requirements.yml
+++ b/rosa-ee/requirements.yml
@@ -1,0 +1,6 @@
+---
+collections:
+  - name: amazon.aws
+  - name: community.aws
+  - name: ansible.posix
+  - name: ansible.controller

--- a/rosa-ee/validate-ee.yml
+++ b/rosa-ee/validate-ee.yml
@@ -1,0 +1,45 @@
+---
+- name: Validate ROSA EE tooling
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Check rosa CLI
+      ansible.builtin.command: rosa version
+      register: rosa_ver
+      changed_when: false
+
+    - name: Check AWS CLI
+      ansible.builtin.command: aws --version
+      register: aws_ver
+      changed_when: false
+
+    - name: Check jq
+      ansible.builtin.command: jq --version
+      register: jq_ver
+      changed_when: false
+
+    - name: Check oc client
+      ansible.builtin.command: oc version --client
+      register: oc_ver
+      changed_when: false
+
+    - name: Check ROSA login (requires ROSA_TOKEN env var)
+      ansible.builtin.command: rosa login --token={{ lookup('env', 'ROSA_TOKEN') }}
+      register: rosa_login
+      changed_when: false
+      when: lookup('env', 'ROSA_TOKEN') | length > 0
+
+    - name: Check AWS identity (requires AWS credentials)
+      amazon.aws.aws_caller_info: {}
+      register: aws_id
+      when: lookup('env', 'AWS_ACCESS_KEY_ID') | length > 0
+
+    - name: Display results
+      ansible.builtin.debug:
+        msg:
+          - "rosa: {{ rosa_ver.stdout_lines[0] }}"
+          - "aws: {{ aws_ver.stdout }}"
+          - "jq: {{ jq_ver.stdout }}"
+          - "oc: {{ oc_ver.stdout_lines[0] }}"
+          - "rosa_login: {{ rosa_login.stdout | default('skipped - no ROSA_TOKEN') }}"
+          - "aws_identity: {{ aws_id.arn | default('skipped - no AWS creds') }}"


### PR DESCRIPTION
## Summary
- New EE for ROSA (Red Hat OpenShift Service on AWS) create/destroy lifecycle demos
- Includes `rosa` CLI, `aws` CLI v2, `oc` client, `jq`
- Collections: `amazon.aws`, `community.aws`, `ansible.posix`, `ansible.controller`
- Validation playbook for smoke testing
- Full README with build/push/AAP setup instructions

## Image
`quay.io/acme_corp/rosa-ee:latest`

## Scope
Strictly ROSA cluster lifecycle (create + destroy). No app deployment, no operator management.

## Test plan
- [ ] CI build succeeds
- [ ] Image pushed to quay.io
- [ ] Smoke checks pass: `rosa version`, `aws --version`, `jq --version`, `oc version --client`

Made with [Cursor](https://cursor.com)