### PR TITLE
fix(rosa-ee): use explicit base image tag for AAP 2.7

### DIFF
--- a/rosa-ee/execution-environment.yml
+++ b/rosa-ee/execution-environment.yml
@@ -2,7 +2,7 @@
 version: 3
 images:
   base_image:
-    name: registry.redhat.io/ansible-automation-platform-27/ee-minimal-rhel9:latest
+    name: registry.redhat.io/ansible-automation-platform-27/ee-minimal-rhel9:2.16
 
 dependencies:
   galaxy: requirements.yml


### PR DESCRIPTION
## Summary
- Fixes rosa-ee build: AAP 2.7 images don't support `:latest` tag
- Uses `:2.16` explicitly (same as aws_gameday_ee)
- network-ee failure was transient Automation Hub 400 (unrelated)

## Test plan
- [ ] rosa-ee build succeeds

Made with [Cursor](https://cursor.com)