### PR TITLE
fix(rosa-ee): resolve missing ansible module in build

### DIFF
--- a/rosa-ee/execution-environment.yml
+++ b/rosa-ee/execution-environment.yml
@@ -18,7 +18,7 @@ options:
 
 additional_build_steps:
     prepend_base:
-        - RUN microdnf install -y python3-pip && python3 -m pip install --upgrade pip setuptools
+        - RUN $PYCMD -m ensurepip
     prepend_galaxy:
         - ADD _build/configs/ansible.cfg /etc/ansible/ansible.cfg
         - ARG AH_TOKEN

--- a/rosa-ee/requirements.txt
+++ b/rosa-ee/requirements.txt
@@ -1,3 +1,5 @@
+ansible-core>=2.16
+ansible-runner
 boto3>=1.28.0
 botocore>=1.31.0
 requests


### PR DESCRIPTION
## Summary
- Replaced aggressive `microdnf install python3-pip && pip install --upgrade pip setuptools` with gentler `$PYCMD -m ensurepip` in prepend_base (aligns with network-ee pattern)
- Added `ansible-core>=2.16` and `ansible-runner` to requirements.txt as safety net

The previous pip upgrade was disrupting the pre-installed ansible-core from the ee-minimal-rhel9:2.16 base image, causing `ModuleNotFoundError: No module named 'ansible'` during the build's check_ansible step.

Made with [Cursor](https://cursor.com)