### PR TITLE
fix(rosa-ee): install python3-pip without upgrading

### DIFF
--- a/rosa-ee/execution-environment.yml
+++ b/rosa-ee/execution-environment.yml
@@ -18,7 +18,7 @@ options:
 
 additional_build_steps:
     prepend_base:
-        - RUN $PYCMD -m ensurepip
+        - RUN microdnf install -y python3-pip && microdnf clean all
     prepend_galaxy:
         - ADD _build/configs/ansible.cfg /etc/ansible/ansible.cfg
         - ARG AH_TOKEN


### PR DESCRIPTION
Install python3-pip via microdnf but skip the pip/setuptools upgrade that disrupts pre-installed ansible-core. ensurepip module is not available on ee-minimal-rhel9:2.16.

Made with [Cursor](https://cursor.com)