### PR TITLE
fix(rosa-ee): remove ansible-core from pip requirements

### DIFF
--- a/rosa-ee/requirements.txt
+++ b/rosa-ee/requirements.txt
@@ -1,5 +1,3 @@
-ansible-core>=2.16
-ansible-runner
 boto3>=1.28.0
 botocore>=1.31.0
 requests


### PR DESCRIPTION
ansible-core is pre-installed in the ee-minimal-rhel9 base image. The >=2.16 pin was unresolvable on this image's Python 3.9.

Made with [Cursor](https://cursor.com)