### PR TITLE
fix(rosa-ee): switch to ee-supported-rhel9 base image

### DIFF
--- a/rosa-ee/execution-environment.yml
+++ b/rosa-ee/execution-environment.yml
@@ -2,7 +2,7 @@
 version: 3
 images:
   base_image:
-    name: registry.redhat.io/ansible-automation-platform-27/ee-minimal-rhel9:2.16
+    name: 'registry.redhat.io/ansible-automation-platform-26/ee-supported-rhel9:latest'
 
 dependencies:
   galaxy: requirements.yml
@@ -18,7 +18,7 @@ options:
 
 additional_build_steps:
     prepend_base:
-        - RUN microdnf install -y python3-pip && microdnf clean all
+        - RUN $PYCMD -m ensurepip
     prepend_galaxy:
         - ADD _build/configs/ansible.cfg /etc/ansible/ansible.cfg
         - ARG AH_TOKEN


### PR DESCRIPTION
ee-minimal-rhel9:2.16 has a Python 3.12/3.9 mismatch that breaks ansible-builder's check_ansible step. Switch to ee-supported-rhel9:latest (same proven pattern as network-ee).

Made with [Cursor](https://cursor.com)