### PR TITLE
fix(rosa-ee): add systemd-devel and pkgconf to bindep

### DIFF
--- a/rosa-ee/bindep.txt
+++ b/rosa-ee/bindep.txt
@@ -1,2 +1,4 @@
 python3-devel [compile platform:rhel-9]
 gcc [compile platform:rhel-9]
+systemd-devel [compile platform:rhel-9]
+pkgconf [compile platform:rhel-9]


### PR DESCRIPTION
Required to compile Python systemd bindings pulled in by ansible.controller collection dependencies.

Made with [Cursor](https://cursor.com)